### PR TITLE
Add PredictionGuard

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.
 - [LlamaIndex](https://www.llamaindex.ai/) - A data framework for building LLM applications over external data.
 - [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine tune LLM, CV and tabular models.
+- [Prediction Guard](https://www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.
 
 ## Code
 


### PR DESCRIPTION
Let me know if I put it under the wrong sub-section. One of the really cool things about Prediction Guard is that it can "fall back" to another model in situations where the main model is unavailable. For example, if ChatGPT is down use LLAMA2 instead. Hope this is helpful! 😎 