### PR TITLE
Add link for Seearch answer engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 - [Kazimir.ai](https://kazimir.ai/) - A search engine designed to search AI-generated images. 
 - [Perplexity AI](https://www.perplexity.ai/) - AI powered search tools.
+- [Seearch](https://seearch.co/) - AI search engine with rigorous grounding
 - [Metaphor](https://metaphor.systems/) - Language model powered search.
 - [Phind](https://phind.com/) - AI-based search engine.
 - [You.com](https://you.com/) - A search engine built on AI that provides users with a customized search experience while keeping their data 100% private.


### PR DESCRIPTION
Not sure if Seearch has been featured on the Altern Newsletter before, but its missing from the list.

Also, the link for "Metaphor" (the one below) seems to have changed, maybe update in the list accordingly.