### PR TITLE
Added one useful resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ChatGPT prompt engineering for developers](https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/) - A short course by Isa Fulford (OpenAI) and Andrew Ng (DeepLearning.AI).
 - [OpenAI Cookbook](https://github.com/openai/openai-cookbook) - Examples and guides for using the OpenAI API.
 - [Robert Miles AI Safety](https://www.youtube.com/@RobertMilesAI) - Youtube channel about AI safety
+- [How to Become a Prompt Engineer? - Scaler Blogs](https://www.scaler.com/blog/how-to-become-a-prompt-engineer/) - Offers a clear roadmap for aspiring prompt engineers in AI.
 
 ## Learn AI free
 ### Machine Learning


### PR DESCRIPTION
Added the How to Become a Prompt Engineer? - Scaler Blogs URL to the section - Learning resources, providing useful insights to aspiring Prompt Engineers, AI, or tech professionals.

Please let me know if further changes are required.

Thank you!