### PR TITLE
Add SearchApi to search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Komo AI](https://komo.ai/) - An AI based Search engine which responses quick and short answers.
 - [Telborg](https://telborg.com/) - AI for Climate Research, with data exclusively from governments, international institutions and companies.
 - [MemFree](https://github.com/memfreeme/memfree) - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs
+- [SearchApi](https://www.searchapi.io/) - Real-time SERP API. Retrieve results from Google, Bing, Baidu, and other search engines.
 
 ### Local search engines
 


### PR DESCRIPTION
Add SearchApi to Search engines.

We provide Google, Baidu, Bing, Amazon, YouTube, and more search engines.