### PR TITLE
Add blank-space to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
+- [blank-space](https://www.blankspace.build/) - Open-source AI app builder. Alternative to v0, Lovable, and Bolt.
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.


### PR DESCRIPTION
## Summary

Adding [blank-space](https://www.blankspace.build/) to the **Developer tools** section.

## Details

- **Repository**: https://github.com/BrandeisPatrick/blank-space
- **Website**: https://www.blankspace.build/
- **Description**: An open-source AI app builder alternative to v0, Lovable, and Bolt
- **Category**: Developer tools / AI app builder

blank-space is a powerful developer tool that enables building applications using AI without extensive coding, making it a perfect fit for the Developer tools section.