### PR TITLE
Add Conduit8 - CLI registry for Claude Code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 - [GitHub Copilot](https://github.com/features/copilot) - GitHub Copilot uses the OpenAI Codex to suggest code and entire functions in real-time, right from your editor.
 - [poorcoder](https://github.com/vgrichina/poorcoder) - Lightweight Bash scripts that enhance your terminal coding workflow with web-based AI assistants like Claude or Grok without disrupting your development process.
+- [Conduit8](https://github.com/conduit8/conduit8) - CLI registry for discovering, installing, and managing Claude Code skills with one-command installation.
 - [OpenAI Codex](https://platform.openai.com/docs/guides/code/) - An AI system by OpenAI that translates natural language to code.
 - [Ghostwriter](https://blog.replit.com/ai) - An AI-powered pair programmer by Replit.
 - [GoCodeo](https://www.gocodeo.com/)- An AI Coding & Testing Agent.


### PR DESCRIPTION
## Description

Adds [Conduit8](https://github.com/conduit8/conduit8) to the Code section.

## What is Conduit8?

Conduit8 is a CLI registry for discovering, installing, and managing Claude Code skills. It provides:
- Search 20+ curated skills by keyword or category
- One-command installation directly to ~/.claude/skills/
- CLI-based skill management (list, remove)
- Like npm/pip for Claude Code skills

## Category

Added to: **Code** (Developer Tools)

## Installation

```bash
npx conduit8 search skills
npx conduit8 install skill <name>
```

## Website

https://conduit8.dev

## License

AGPL-3.0