### PR TITLE
Add Promptext

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI2sql](https://www.ai2sql.io/) - With AI2sql, engineers and non-engineers can easily write efficient, error-free SQL queries without knowing SQL.
 - [CodiumAI](https://www.codium.ai/) - With CodiumAI, you get non-trivial tests suggested right inside your IDE, so you stay confident when you push.
 - [PR-Agent](https://github.com/Codium-ai/pr-agent) - AI-powered tool for automated PR analysis, feedback, suggestions, and more.
-- [Promptext](https://github.com/1broseidon/promptext) - Smart code context extractor for AI assistants. Analyzes codebases, filters relevant files, and provides formatted output optimized for AI prompts with accurate token counting.
+- [Promptext](https://github.com/1broseidon/promptext) - Extracts and formats code context for AI assistants with token counting. #opensource
 - [MutableAI](https://mutable.ai/) - AI Accelerated Software Development.
 - [TurboPilot](https://github.com/ravenscroftj/turbopilot) - A self-hosted copilot clone that uses the library behind llama.cpp to run the 6 billion parameter Salesforce Codegen model in 4 GB of RAM.
 - [GPT-Code UI](https://github.com/ricklamers/gpt-code-ui) - An open-source implementation of OpenAI's ChatGPT Code interpreter.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI2sql](https://www.ai2sql.io/) - With AI2sql, engineers and non-engineers can easily write efficient, error-free SQL queries without knowing SQL.
 - [CodiumAI](https://www.codium.ai/) - With CodiumAI, you get non-trivial tests suggested right inside your IDE, so you stay confident when you push.
 - [PR-Agent](https://github.com/Codium-ai/pr-agent) - AI-powered tool for automated PR analysis, feedback, suggestions, and more.
-- [Promptext](https://github.com/1broseidon/promptext) - Extracts and formats code context for AI assistants with token counting. #opensource
+- [Promptext](https://github.com/1broseidon/promptext) - Extracts and formats code context for AI assistants with token counting.
 - [MutableAI](https://mutable.ai/) - AI Accelerated Software Development.
 - [TurboPilot](https://github.com/ravenscroftj/turbopilot) - A self-hosted copilot clone that uses the library behind llama.cpp to run the 6 billion parameter Salesforce Codegen model in 4 GB of RAM.
 - [GPT-Code UI](https://github.com/ricklamers/gpt-code-ui) - An open-source implementation of OpenAI's ChatGPT Code interpreter.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI2sql](https://www.ai2sql.io/) - With AI2sql, engineers and non-engineers can easily write efficient, error-free SQL queries without knowing SQL.
 - [CodiumAI](https://www.codium.ai/) - With CodiumAI, you get non-trivial tests suggested right inside your IDE, so you stay confident when you push.
 - [PR-Agent](https://github.com/Codium-ai/pr-agent) - AI-powered tool for automated PR analysis, feedback, suggestions, and more.
+- [Promptext](https://github.com/1broseidon/promptext) - Smart code context extractor for AI assistants. Analyzes codebases, filters relevant files, and provides formatted output optimized for AI prompts with accurate token counting.
 - [MutableAI](https://mutable.ai/) - AI Accelerated Software Development.
 - [TurboPilot](https://github.com/ravenscroftj/turbopilot) - A self-hosted copilot clone that uses the library behind llama.cpp to run the 6 billion parameter Salesforce Codegen model in 4 GB of RAM.
 - [GPT-Code UI](https://github.com/ricklamers/gpt-code-ui) - An open-source implementation of OpenAI's ChatGPT Code interpreter.


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** Promptext
- **Description:** Extracts and formats code context for AI assistants with token counting.
- **Tool URL:** https://github.com/1broseidon/promptext
- **Altern.ai page link:** N/A

## 📌 Description
Adding Promptext to the Code section.

Promptext is a CLI tool that helps developers prepare code context for AI assistants by filtering relevant files and providing accurate token counts.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool

---

## 💡 Additional Notes
Promptext is a Go-based CLI tool (v0.5.1) that uses tiktoken for accurate GPT-compatible token counting. It's actively maintained with GitHub Actions CI/CD and 82% test coverage.