### PR TITLE
Add Mountain Route Researcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Have I Been Trained?](https://haveibeentrained.com/) - Check if your image has been used to train popular AI art models.
 - [AI Dungeon](https://aidungeon.io/) - A text-based adventure-story game you direct (and star in) while the AI brings it to life.
 - [Clickable](https://www.clickable.so/) - Generate ads in seconds with AI. Beautiful, brand-consistent, and highly converting ads for all marketing channels.
+- [Mountain Route Researcher](https://github.com/dreamiurg/claude-mountaineering-skills) - Claude Code plugin for automating mountain route research across 10+ specialized sources, reducing research time from hours to minutes.
 - [Scale Spellbook](https://scale.com/spellbook) - Build, compare, and deploy large language model apps with Scale Spellbook.
 - [Scenario](https://www.scenario.com/) - AI-generated gaming assets.
 - [Teleprompter](https://github.com/danielgross/teleprompter) - An on-device AI for your meetings that listens to you and makes charismatic quote suggestions.


### PR DESCRIPTION
Built this to automate my mountain route research workflow - was spending 3-5 hours before each climb checking a dozen specialized sites manually.

Aggregates data from 10+ mountaineering sources (PeakBagger, SummitPost, WTA, AllTrails, weather services, avalanche centers, etc.) into route beta reports in ~5 minutes. The AI synthesizes trip reports from multiple sources, analyzes hazards, and structures everything into organized reports.

Works with 150k+ North American peaks. Three example reports in the repo showing different mountain types.

https://github.com/dreamiurg/claude-mountaineering-skills