### PR TITLE
Add promptfoo - LLM evaluation and red teaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source LLM evaluation and red teaming framework. Compare prompts, models, and RAG architectures. Test with multi-turn adversarial attacks and catch security vulnerabilities in CI/CD. #opensource
 
 
 ## Code


### PR DESCRIPTION
Adds [promptfoo](https://github.com/promptfoo/promptfoo) to the AI tools list.

**promptfoo** is an open-source LLM evaluation and red teaming framework with 250K+ developers. It allows teams to:

- Compare prompts, models, and RAG architectures
- Run multi-turn adversarial attacks (PAIR, tree-of-attacks, crescendo)
- Catch security vulnerabilities in CI/CD pipelines

Featured in OpenAI Build Hours and Anthropic's courses. Fits alongside other evaluation tools like Agenta and Opik.