### PR TITLE
Add Vedika AI to Other section

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
 - [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
 - [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
-- [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click. 
+- [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click.
+- [Vedika](https://vedika.io) - AI-powered Vedic astrology API with birth charts, compatibility matching, and natural language predictions in 22 languages. 
 - [StarOps](https://ingenimax.ai) - AI Platform Engineer
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.


### PR DESCRIPTION
## Add Vedika to Other section

Adding Vedika - an AI-powered Vedic astrology API to the "Other" section.

### About Vedika
- **URL**: https://vedika.io/
- **Description**: AI-powered Vedic astrology API with birth charts, horoscopes, kundali matching, and AI chatbot

### Features
- 108+ API endpoints for Vedic astrology calculations
- AI-powered chatbot for astrology queries (multi-agent swarm architecture)
- Birth chart (Kundali) generation
- Daily/Weekly/Monthly horoscopes
- Kundali matching (36 Guna Milan)
- Panchang calculations
- Numerology analysis
- 22 language support

### Free Access
Vedika offers a FREE Sandbox environment at `api.vedika.io/sandbox/*` with no API key required for development and testing.

### Documentation
- API Docs: https://vedika.io/docs
- Postman Collection available
- SDKs: Python (`vedika-sdk` on PyPI) and JavaScript (`vedika-sdk` on npm)