### PR TITLE
Add Price Per Token to Developer tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Prediction Guard](https://www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.
 - [Portkey](https://portkey.ai/) - Full-stack LLMOps platform to monitor, manage, and improve LLM-based apps.
 - [OpenAI Downtime Monitor](https://status.portkey.ai/) - Free tool that tracks API uptime and latencies for various OpenAI models and other LLM providers.
+- [Price Per Token](https://pricepertoken.com/) - Compare LLM API pricing across 200+ models from OpenAI, Anthropic, Google, and more. Includes token counters and cost calculators.
 - [ChatWithCloud](https://chatwithcloud.ai/) - CLI allowing you to interact with AWS Cloud using human language inside your Terminal.
 - [SinglebaseCloud](https://singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.
 - [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.


### PR DESCRIPTION
Adding Price Per Token (https://pricepertoken.com) to the Developer tools section.

**Why this addition is valuable:**
- Compare LLM API pricing across 200+ models
- Token counter and cost calculator tools
- Covers OpenAI, Anthropic, Google, Meta, and more
- Free to use