### PR TITLE
Add Standards SDK - TypeScript SDK for AI agents on Hedera

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
 - [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
 - [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click. 
+- [Standards SDK](https://hol.org/) - TypeScript SDK for building AI agents on Hedera blockchain with decentralized messaging, state management, and MCP support. [#opensource](https://github.com/hashgraph-online/standards-sdk)
 - [StarOps](https://ingenimax.ai) - AI Platform Engineer
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.


### PR DESCRIPTION
Adding Standards SDK to the Developer tools section.

Standards SDK is an open-source TypeScript framework for building AI agents on the Hedera network.

- GitHub: https://github.com/hashgraph-online/standards-sdk
- NPM: @hashgraphonline/standards-sdk