### PR TITLE
feat: add mcp benchmarking tool to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [mcpbr](https://github.com/greynewell/mcpbr) - Benchmark runner for evaluating Model Context Protocol (MCP) server performance and agentic capabilities. [#opensource](https://github.com/greynewell/mcpbr)
 
 
 ## Code


### PR DESCRIPTION
Hi! I've added a benchmarking runner for Model Context Protocol (MCP) servers to the Developer tools section. As AI agents increasingly rely on MCP for tool integration, this tool helps developers validate their MCP server implementations. Thanks!