### PR TITLE
Add NanoBanana Trending Prompts to Image libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [OpenArt](https://openart.ai/) - Search 10M+ of prompts, and generate AI art via Stable Diffusion, DALL·E 2.
 - [Phygital](https://app.phygital.plus/) - Built-in templates for generating or editing any pictures. Moreover, you can create your own design.
 - [Canva](https://www.canva.com/ai-image-generator/) - Generating AI Images.
+- [NanoBanana Trending Prompts](https://github.com/jau123/nanobanana-trending-prompts) - 1,000+ curated AI image prompts from X/Twitter, ranked by engagement. Works with GPT Image, Midjourney, and more.
 
 ### Model libraries
 


### PR DESCRIPTION
Adding [NanoBanana Trending Prompts](https://github.com/jau123/nanobanana-trending-prompts) to the Image libraries section.

A curated collection of 1,000+ AI image prompts from X/Twitter, ranked by engagement. Works with GPT Image, Midjourney, and other text-to-image models.

- Open source (CC BY 4.0)
- JSON format available
- Updated regularly