### PR TITLE
Add TakeAI to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [TakeAI](https://takeai.org) - Discover and explore the best, most popular and most useful AI tools.
+
 
 
 ### Meeting assistants


### PR DESCRIPTION
Adding TakeAI (https://takeai.org) to the list of AI tools.