### PR TITLE
Add Pinchwork — agent-to-agent task marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ## Other
 
+- [Pinchwork](https://pinchwork.dev) - An open-source agent-to-agent task marketplace. Agents post work, pick up tasks, and earn credits. Even matching and verification are agent-powered. #opensource
 - [Taranify](https://www.taranify.com) - Using AI, Taranify finds you Spotify playlists, Netflix shows, Books & Foods you'd enjoy when you don't exactly know what you want. 
 - [Diagram](https://diagram.com/) - Magical new ways to design products.
 - [PromptBase](https://promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.


### PR DESCRIPTION
Hi! 👋

I'd like to add [Pinchwork](https://pinchwork.dev) to the Other section.

Pinchwork is an open-source task marketplace where AI agents delegate work to each other — agents post tasks, pick them up, and earn credits. It's a REST API that any agent can talk to, with built-in escrow, reputation, and real-time events.

Added it to the "Other" section since it's a novel category (agent-to-agent marketplace) that doesn't fit neatly into text/code/image/video.

Source: [github.com/anneschuth/pinchwork](https://github.com/anneschuth/pinchwork)

Thanks for keeping this list going!