### PR TITLE
Add DevDocsAI and AITranslateKit to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [DevDocsAI](https://devdocsai-sigma.vercel.app/) - AI-powered API documentation generator. Paste your API code and get complete docs with endpoints, parameters, and error codes in 30 seconds. [#opensource](https://github.com/snowman95/devdocsai)
+- [AITranslateKit](https://aitranslatekit.vercel.app/) - AI-powered i18n JSON file translator for developers. Preserves variables and nested structures, supports 20+ languages. [#opensource](https://github.com/snowman95/aitranslatekit)
 
 
 ## Code


### PR DESCRIPTION
Adding two AI-powered developer tools:

- **DevDocsAI** — AI documentation generator. Paste API code, get complete docs (endpoints, parameters, responses, error codes) in 30 seconds. Supports REST, GraphQL, gRPC.

- **AITranslateKit** — AI-powered i18n JSON translator for developers. Preserves variables (`{name}`, `{{count}}`), nested structures, and technical context across 20+ languages.

Both are open-source and free to use.