### PR TITLE
Add Brighten to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[Brighten](https://hellobrighten.com/)** - AI-powered employee recognition and onboarding platform for SMBs with smart recognition suggestions and automated workflows.
 
 
 ### Phone Calls


### PR DESCRIPTION
Adding [Brighten](https://hellobrighten.com) to the Marketing AI Tools section.

Brighten is an AI-powered employee recognition and onboarding platform for small businesses. It uses machine learning to generate personalized recognition suggestions, automate onboarding workflows, and integrate with Slack/Teams. Free tier available, paid plans from $4/user/month.

Launched February 2026.