### PR TITLE
Add OpenClaw to Chatbots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gali Chat](https://www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
 - [DeepSeek-R1](https://www.deepseek.com) - *[reviews](https://altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
 - [dmwithme](https://dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
+- [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted AI assistant that connects Claude to WhatsApp, Telegram, Discord, Slack, and more from a single deployment. #opensource ([docs](https://clawdbot.blog/))
 
 
 ### Search engines


### PR DESCRIPTION
Adding [OpenClaw](https://github.com/openclaw/openclaw) to the Chatbots section.

OpenClaw is an open-source, self-hosted AI assistant that connects Claude to multiple messaging platforms (WhatsApp, Telegram, Discord, Slack, iMessage, SMS, Email, Signal) from a single deployment. It supports custom hooks, plugins, and tools for extensibility.

- **GitHub**: https://github.com/openclaw/openclaw (190k+ stars)
- **License**: MIT
- **Language**: TypeScript