### PR TITLE
Add GroAsk - macOS AI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [GroAsk](https://groask.com/) - macOS menu bar AI launcher that provides quick access to multiple AI services with a customizable hotkey.
 
 
 ### Meeting assistants


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** GroAsk
- **Description:** macOS menu bar AI launcher with quick access to multiple AI services via customizable hotkey (⌥Space).
- **Tool URL:** https://groask.com/

## Checklist
- [x] Only one tool is modified in this PR
- [x] All required fields provided
- [x] Tool link is valid and accessible
- [x] Tool is not already listed
- [x] Tool is placed in the correct category
- [x] Tool is added at the end of its category
- [x] No unrelated changes included