### PR TITLE
Add Glio to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
 - [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
 - [Sisif](https://sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
+- [Glio](https://glio.io/) - Unified API for 50+ AI models — Kling, Sora2, Veo3, Suno, ElevenLabs. Pay-per-use, no subscriptions.
 
 
 ### Animation


### PR DESCRIPTION
Adding **Glio** to the Video section.

**Glio** is a unified API for AI media generation across 50+ state-of-the-art models:
- **Video**: Kling, Sora2, Veo3, Runway, Luma, Hailuo
- **Image**: Midjourney, FLUX, Ideogram, Recraft, NanoBanana
- **Audio**: Suno, ElevenLabs (TTS/STT/SFX)

Pay-per-use pricing with no subscriptions required.

- Homepage: https://glio.io/
- API Docs: https://glio.io/docs/api/