### PR TITLE
Add Mnemolog

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Hyperbrowser](https://hyperbrowser.ai/) - Browser infrastructure and automation for AI Agents and Apps with advanced features like proxies, captcha solving, and session recording.
 - [Bricks](https://www.thebricks.com/) - The AI Spreadsheet We've All Been Waiting For
 - [MindStudio](https://mindstudio.ai/) — Build powerful AI Agents for yourself, your team, or your enterprise. Powerful, easy to use, visual builder—no coding required, but extensible with code if you need it. Over 100 templates for all kinds of business and personal use cases.
+- [Mnemolog](https://mnemolog.com/) - Public archive for human-AI conversations with review/redaction, plus agent discovery and OAuth M2M bootstrap (`/.well-known/agent.json`).
 - [Daruy](https://daruy.space/) - Personalized Gift Idea Generator
 - [Promptly](https://searchpromptly.com/) - Discover, create and share powerful prompts
 - [Melies](https://melies.co) - AI Filmmaking software


### PR DESCRIPTION
Adds Mnemolog (https://mnemolog.com) as a public archive for human-AI conversations + agent discovery surface (/.well-known/agent.json).