### PR TITLE
Add PM Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [PM Skills](https://github.com/product-on-purpose/pm-skills) - An open-source library of 24 product management agent skills spanning the full product lifecycle, from discovery to delivery. [#opensource](https://github.com/product-on-purpose/pm-skills)
 
 
 ## Code


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** PM Skills
- **Description:** An open-source library of 24 product management agent skills spanning the full product lifecycle, from discovery to delivery.
- **Tool URL:** https://github.com/product-on-purpose/pm-skills
- **Altern.ai page link:** N/A

## Description
Adding PM Skills to the Developer tools section. PM Skills is an open-source (Apache 2.0) library of 24 structured product management agent skills that follow the agentskills.io specification, covering the full PM lifecycle from discovery through delivery.

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

## Type of Change
- [x] Adding a new AI tool

## Additional Notes
PM Skills follows the agentskills.io specification and is licensed under Apache 2.0.