### PR TITLE
Add goMacro.ai - AI economic calendar for traders

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Scenario](https://www.scenario.com/) - AI-generated gaming assets.
 - [Teleprompter](https://github.com/danielgross/teleprompter) - An on-device AI for your meetings that listens to you and makes charismatic quote suggestions.
 - [FinChat](https://finchat.io/) - Using AI, FinChat generates answers to questions about public companies and investors.
+- [goMacro.ai](https://gomacro.ai) - AI-powered economic calendar providing institutional-grade macro insights, scenario planning, and portfolio impact analysis for traders.
 - [Petals](https://github.com/bigscience-workshop/petals) - BitTorrent style platform for running AI models in a distributed way.
 - [Shotstack Workflows](https://shotstack.io/product/workflows/) - No-code, automation workflow tool for building Generative AI media applications.
 - [Aispect](https://aispect.io/?ref=mahseema-awesome-ai-tools) - New way to experience events.


### PR DESCRIPTION
## What is goMacro.ai?

[goMacro.ai](https://gomacro.ai) is an AI-powered economic calendar that provides institutional-grade macro insights for traders. It enhances economic calendar events with:

- **AI-generated institutional summaries** on the effects of data prints (NFP, CPI, PPI, etc.)
- **Bull/Bear/Base case scenario planning** for each economic release
- **Portfolio impact analysis** to understand what data means for your positions

Added under **Other** alongside FinChat.io (another AI finance tool).

Free to use with a freemium model.