### PR TITLE
Add BrowserClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.
 - [Calmo](https://getcalmo.com/) - Debug Production x10 Faster with AI.
+- [BrowserClaw](https://github.com/idan-rubin/browserclaw) - AI browser automation via accessibility snapshot and ref targeting. Built on Playwright. No vision model, no CSS selectors — snapshot the page, AI picks a ref, library hits the exact element.
 - [Cleanlab](https://help.cleanlab.ai/tlm/) - Detect and remediate hallucinations in any LLM application.
 - [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows.


### PR DESCRIPTION
BrowserClaw is an open-source library for AI browser automation using accessibility snapshots and ref targeting, built on Playwright.

Instead of vision models or CSS selectors, it snapshots the page's accessibility tree into a numbered text map. The AI picks a ref, the library resolves it to the exact Playwright element — deterministic, fast, no vision API cost.

https://github.com/idan-rubin/browserclaw