### PR TITLE
Add Mantra - time-travel debugger for AI coding sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.
 - [Calmo](https://getcalmo.com/) - Debug Production x10 Faster with AI.
+- [Mantra](https://mantra.gonewx.com/) - A time-travel debugger for AI coding sessions. Replay, inspect, and understand what happened during agentic coding workflows.
 - [Cleanlab](https://help.cleanlab.ai/tlm/) - Detect and remediate hallucinations in any LLM application.
 - [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows.


### PR DESCRIPTION
## What is Mantra?

[Mantra](https://mantra.gonewx.com/) is a time-travel debugger for AI coding sessions. It lets you replay, inspect, and understand what happened during agentic coding workflows.

- Website: https://mantra.gonewx.com/
- Releases: https://github.com/mantra-hq/mantra-releases

## Where is it added?

Added to the **Developer tools** section, alongside other debugging and observability tools like Calmo and Langfuse.