### PR TITLE
Add tokf to Developer tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
+- [tokf](https://github.com/mpecan/tokf) - Config-driven CLI that compresses command output (git, cargo, docker, npm, kubectl, etc.) before it reaches an LLM context window, reducing token usage by 60–90%. Integrates with Claude Code as a PreToolUse hook.
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
 
 


### PR DESCRIPTION
## 📝 New Tool Information

- **Tool Name:** tokf
- **Description:** Config-driven CLI that compresses command output before it reaches an LLM context window, reducing token usage by 60–90%.
- **Tool URL:** https://github.com/mpecan/tokf
- **Altern.ai page link:** N/A

## 📌 Description

Adds [tokf](https://github.com/mpecan/tokf) to the Developer tools section. tokf is an open-source Rust CLI that intercepts command output (git, cargo, docker, npm, kubectl, pytest, tsc, and more) and compresses it via TOML-defined filters before it reaches an LLM agent's context window. It integrates with Claude Code as a `PreToolUse` hook (`tokf hook install --global`) and typically reduces output by 60–90%. Installable via `brew install mpecan/tokf/tokf` or `cargo install tokf`.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool