### PR TITLE
Add Signal AI Digest — AI-curated personalized daily news via Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [Signal AI Digest](https://humanintel.github.io/signal-digest-landing/) - AI-curated daily news digest delivered to Telegram every morning. Monitors 25+ sources (Reuters, Bloomberg, TechCrunch, CoinTelegraph, etc.), matches stories to your personal topics, and delivers 3-10 summarized stories with source citations. Free tier available.
 
 
 ### Meeting assistants


### PR DESCRIPTION
## What is this?

**Signal AI Digest** is an AI-powered personal news curator that delivers a daily digest to your Telegram every morning.

- **Landing page:** https://humanintel.github.io/signal-digest-landing/
- **What it does:** Monitors 25+ RSS sources (Reuters, Bloomberg, TechCrunch, FT, CoinTelegraph, Foreign Policy, Carbon Brief, etc.), matches stories to your personal topic preferences, and delivers 3-10 AI-summarized stories with original source citations.
- **Free tier:** 3 stories/day, no credit card required
- **Paid tier:** $5/month for 10 stories/day
- **Delivery:** Telegram bot (@SignalDigest_Bot)

## Why it belongs here

It is a genuine AI productivity tool — uses GPT-4o-mini for summarization and relevance scoring to replace 90 minutes of manual news browsing with a focused 10-minute read. Relevant to the Productivity section alongside similar curation/summarization tools.

## Placement

Added to the **Productivity** section, after X-doc AI.