### PR TITLE
Add OpenAgents — open-source AI agent network platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [OpenAgents](https://github.com/openagents-org/openagents) - Open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A). [#opensource](https://github.com/openagents-org/openagents)
 
 
 ## Code


### PR DESCRIPTION
## Summary

- Adds [OpenAgents](https://github.com/openagents-org/openagents) to the **Developer tools** section.
- OpenAgents is an open-source platform for building AI agent networks with multi-protocol support (WebSocket, gRPC, HTTP, MCP, A2A).
- Entry follows the existing list format and includes the `#opensource` tag linking to the GitHub repository.

## Details

OpenAgents provides infrastructure for creating interconnected AI agent networks. It supports multiple communication protocols — WebSocket, gRPC, HTTP, MCP, and A2A — making it versatile for different agent integration scenarios. The project is fully open source on GitHub.