### PR TITLE
Add Claude PR Reviewer to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Bing Chat](https://www.bing.com/chat) - *[reviews](https://altern.ai/product/bing_chat)* - A conversational AI language model powered by Microsoft Bing.
 - [Gemini](https://gemini.google.com) - *[reviews](https://altern.ai/product/gemini)* - An experimental AI chatbot by Google, powered by the LaMDA model.
 - [Character.AI](https://character.ai/) - *[reviews](https://altern.ai/product/character-ai)* - Character.AI lets you create characters and chat to them.
+- [Breezy](https://talkbreezy.com/) - Real-time AI voice chat with unique characters. Talk naturally and hear responses instantly.
 - [ChatPDF](https://www.chatpdf.com/) - *[reviews](https://altern.ai/product/chatpdf)* - Chat with any PDF.
 - [ChatSonic](https://writesonic.com/chat) - *[reviews](https://altern.ai/product/chatsonic)* - An AI-powered assistant that enables text and image creation.
 - [Phind](https://www.phind.com/) - *[reviews](https://altern.ai/product/phind)* - Phind is an intelligent search engine and assistant for programmers. Phind is smart enough to proactively ask you questions to clarify its assumptions and to browse the web (or your codebase) when it needs additional context. With our new VS Code extension.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [Claude PR Reviewer](https://github.com/indoor47/claude-pr-reviewer) - GitHub Action and CLI tool for AI-powered code review using Claude. Zero dependencies, Python 3.8+ stdlib only.
 
 
 ## Image


### PR DESCRIPTION
## Summary

Adds [Claude PR Reviewer](https://github.com/indoor47/claude-pr-reviewer) to the **Code** section.

## About the tool

Claude PR Reviewer is a GitHub Action and CLI tool for AI-powered code review using Claude. It runs as a GitHub Action (auto-posts review comments on PRs) or standalone CLI (outputs to stdout). Zero external dependencies — uses only Python 3.8+ standard library.

- **GitHub Action**: Triggers on PR events, posts inline review comments
- **CLI mode**: Run locally for quick code review from the terminal
- **Zero dependencies**: Pure Python stdlib, no pip install needed
- **Configurable**: Supports Claude Sonnet (default), Opus, and Haiku models

**Entry added:**
```
- [Claude PR Reviewer](https://github.com/indoor47/claude-pr-reviewer) - GitHub Action and CLI tool for AI-powered code review using Claude. Zero dependencies, Python 3.8+ stdlib only.
```

Repo: https://github.com/indoor47/claude-pr-reviewer