### PR TITLE
Add TutuoAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ## Other
 
+- [TutuoAI](https://www.tutuoai.com/) — $1 agent marketplace: skills, tools, configs — built for agents
 - [Taranify](https://www.taranify.com) - Using AI, Taranify finds you Spotify playlists, Netflix shows, Books & Foods you'd enjoy when you don't exactly know what you want. 
 - [Diagram](https://diagram.com/) - Magical new ways to design products.
 - [PromptBase](https://promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.


### PR DESCRIPTION
Adds TutuoAI (https://www.tutuoai.com/) — a  agent marketplace (skills/tools/configs) built for agents.