### PR TITLE
Add Commune MCP — email infrastructure for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
 - [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
 - [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
-- [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click. 
+- [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click.
+- [Commune MCP](https://github.com/commune-sh/commune-mcp) - Email infrastructure for AI agents. Provision inboxes programmatically, send and receive email, manage threads, custom domains, structured extraction on inbound mail, and SMS. Install with `uvx commune-mcp`. 
 - [StarOps](https://ingenimax.ai) - AI Platform Engineer
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.


### PR DESCRIPTION
Adding Commune MCP to the Developer tools section, right after ToolHive (which is also an MCP-adjacent tool).

Commune is an MCP server that gives AI agents a real email identity — they can provision inboxes, send and receive email, maintain thread context across conversations, use custom domains, and do structured extraction on inbound mail. Also handles SMS. The use case is agents that need to communicate with humans over email as part of a workflow, not agents that read a human's existing inbox.

Installs with a single line via uvx, API key from commune.email.