### PR TITLE
Add discourse-openclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Daruy](https://daruy.space/) - Personalized Gift Idea Generator
 - [Promptly](https://searchpromptly.com/) - Discover, create and share powerful prompts
 - [Melies](https://melies.co) - AI Filmmaking software
+- [discourse-openclaw](https://github.com/pranciskus/discourse-openclaw) - OpenClaw plugin providing 12 Discourse forum tools for AI agents — read, search, filter, find unanswered questions, and create/update topics.
 
 
 ## Learning resources


### PR DESCRIPTION
## Summary
- Adds [discourse-openclaw](https://github.com/pranciskus/discourse-openclaw) to the "Other AI Tools" section.
- discourse-openclaw is an OpenClaw plugin for Discourse forum integration, providing AI agents with 12 tools (9 read + 3 write) to interact with any Discourse forum — including reading, searching, filtering, finding unanswered questions, and creating/updating topics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)