### PR TITLE
Add StackBuilt to Related Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,5 +590,6 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Awesome Marketing](https://github.com/marketingtoolslist/awesome-marketing)
 - [Top AI Directories](https://github.com/best-of-ai/ai-directories) - An awesome list of best top AI directories to submit your ai tools
 
+- [StackBuilt](https://stackbuilt.co) - Curated AI tool stacks and honest reviews for solopreneurs. No sponsored content, just tools that work.
 
 created by [Mahsima Dastan](https://github.com/mahseema)


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** StackBuilt
- **Description:** Curated AI tool stacks and honest reviews for solopreneurs. No sponsored content, just tools that work.
- **Tool URL:** https://stackbuilt.co
- **Altern.ai page link:** (not available)

## 📍 Description
Added StackBuilt (https://stackbuilt.co) to the Related Awesome Lists section. StackBuilt is a curated AI tools resource site focused on solopreneurs, featuring honest tool reviews, comparison posts, and curated stacks — no sponsored content.

---

## ✅ Checklist
- [x] I have read the Contribution Guidelines
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**