### PR TITLE
Add CallStack LLM Gateway to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
 - [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
 - [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
+- [CallStack LLM Gateway](https://callstack-api.vercel.app) - Open-source LLM API gateway — one endpoint for OpenAI, Anthropic, Gemini, and DeepSeek with automatic failover, cost tracking, and streaming. BYOK. [#opensource](https://github.com/alenmanjgafic/callstack)
 - [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click. 
 - [StarOps](https://ingenimax.ai) - AI Platform Engineer
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.


### PR DESCRIPTION
Adding [CallStack LLM Gateway](https://callstack-api.vercel.app) — an open-source LLM API gateway that provides one unified endpoint for OpenAI, Anthropic, Google Gemini, and DeepSeek.

**Key features:**
- Automatic failover across 4 LLM providers
- OpenAI-compatible API (drop-in replacement)
- Cost tracking per request
- Full SSE streaming for all providers
- BYOK (Bring Your Own Keys) — free, zero markup
- Node.js SDK: [callstack-ai on npm](https://www.npmjs.com/package/callstack-ai)

**Links:**
- Live API: https://callstack-api.vercel.app
- Docs: https://callstack-api.vercel.app/docs
- GitHub: https://github.com/alenmanjgafic/callstack