### PR TITLE
Add rule-gen to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
 
 
+- [rule-gen](https://github.com/nedcodes-ok/rule-gen) - Generate AI coding rules from your actual codebase using Google Gemini. Feeds source files into Gemini's 1M token context window and produces project-specific rules for Cursor, Claude Code, Copilot, and Windsurf. Zero dependencies.
 ## Image
 
 *For a more complete list of AI Image tools visit: [Best Image AI Tools](https://github.com/mahseema/awesome-ai-tools/blob/main/IMAGE.md) or [Awesome AI Image](https://github.com/xaramore/awesome-ai-image)*


### PR DESCRIPTION
Adds [rule-gen](https://github.com/nedcodes-ok/rule-gen) — a CLI tool that generates AI coding rules from your codebase using Google Gemini's 1M token context window. Produces project-specific rules for Cursor (.mdc), Claude Code (CLAUDE.md), Copilot, and Windsurf.

Zero dependencies. npm: `npm install -g rulegen-ai`