### PR TITLE
Add APIClaw - The API layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
+- [APIClaw](https://apiclaw.nordsym.com/) - The API layer for AI agents. 22,000+ APIs indexed with semantic discovery and Direct Call execution via MCP. Giving agents access to real-world APIs. Discovery is free forever. [#opensource](https://github.com/nordsym/apiclaw)
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.


### PR DESCRIPTION
Adding APIClaw to the Developer tools section.

## APIClaw
The API layer for AI agents — giving agents access to real-world APIs.

- **22,000+ APIs indexed** — Semantic discovery by capability
- **18 Direct Call providers** — Execute without API keys
- **MCP native** — Works with any MCP-compatible agent
- **Discovery is free forever**

https://github.com/nordsym/apiclaw
https://apiclaw.nordsym.com