### PR TITLE
Add StripFeed – URL to Markdown API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [StripFeed](https://www.stripfeed.dev/) - API that converts any URL to clean Markdown for AI agents and RAG pipelines. Saves 60-80% tokens vs raw HTML. Includes TypeScript/Python SDKs, MCP server, caching, and batch fetch. [#opensource](https://github.com/StripFeed)
 
 
 ## Code


### PR DESCRIPTION
**StripFeed** is an API that converts any URL to clean Markdown for AI agents and RAG pipelines.

- Saves 60-80% tokens compared to feeding raw HTML to LLMs
- TypeScript SDK ([npm](https://www.npmjs.com/package/stripfeed)) and Python SDK ([PyPI](https://pypi.org/project/stripfeed/))
- MCP server for AI coding assistants ([npm](https://www.npmjs.com/package/@stripfeed/mcp-server))
- Caching, batch fetch (up to 10 URLs), CSS selectors, token counting
- Free tier: 200 requests/month

**Links:**
- Website: https://www.stripfeed.dev
- GitHub: https://github.com/StripFeed
- TypeScript SDK: https://github.com/StripFeed/stripfeed-js
- Python SDK: https://github.com/StripFeed/stripfeed-python

Added to the **Developer tools** section.