### PR TITLE
Add OpenClaw MCP Ecosystem to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [OpenClaw MCP Ecosystem](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers) - 9 remote MCP servers on Cloudflare Workers. JSON, regex, colors, timestamps, prompts, AI intel, fortune, publishing, AI comparison. Zero install, streamable-http.
 
 
 ## Image


### PR DESCRIPTION
## Summary
- Adds OpenClaw MCP Ecosystem to the Code section
- 9 remote MCP servers on Cloudflare Workers: JSON, regex, colors, timestamps, prompts, AI intel, fortune, publishing, AI comparison
- Zero install, streamable-http transport, free tier

## Details
- **GitHub**: https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers
- **Transport**: Streamable HTTP
- **Platform**: Cloudflare Workers edge