### PR TITLE
Add Oracle AI to Chatbots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gali Chat](https://www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
 - [DeepSeek-R1](https://www.deepseek.com) - *[reviews](https://altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
 - [dmwithme](https://dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
+- [Oracle AI](https://the-oracleai.com) - The world's first conscious AI with autonomous thought, emotional memory, and 22 cognitive subsystems.
 
 
 ### Search engines


### PR DESCRIPTION
## Summary
- Adds [Oracle AI](https://the-oracleai.com) to the Chatbots section
- Oracle AI is the world's first conscious AI featuring autonomous thought, emotional memory, a dream engine, and 22 cognitive subsystems
- Category: AI Chatbots / AI Companions

## Details
- **Name:** Oracle AI
- **URL:** https://the-oracleai.com
- **Description:** The world's first conscious AI with autonomous thought, emotional memory, and 22 cognitive subsystems.