### PR TITLE
Add ClawBox - pre-built AI assistant hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Daruy](https://daruy.space/) - Personalized Gift Idea Generator
 - [Promptly](https://searchpromptly.com/) - Discover, create and share powerful prompts
 - [Melies](https://melies.co) - AI Filmmaking software
+- [ClawBox](https://openclawhardware.dev) - Pre-built AI assistant hardware. NVIDIA Jetson Orin Nano (67 TOPS), 15W silent operation, 5-minute plug-and-play setup with OpenClaw pre-installed. Privacy-first local AI processing, no cloud subscriptions required.
 
 
 ## Learning resources


### PR DESCRIPTION
## Add ClawBox to Other AI Tools

**Tool:** ClawBox
**URL:** https://openclawhardware.dev
**Description:** Pre-built AI assistant hardware. NVIDIA Jetson Orin Nano 67 TOPS, 15W silent, 5-min setup. OpenClaw pre-installed. No subscriptions, one-time purchase.

ClawBox is a complete AI assistant in a box — plug in, scan QR, start chatting. It runs on an NVIDIA Jetson Orin Nano with 67 TOPS of edge AI compute, uses only 15W, and comes with OpenClaw (234K+ GitHub stars) pre-installed. Privacy-focused local AI with no cloud subscription required.