### PR TITLE
Add Facebook Ad Builder to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[Facebook Ad Builder](https://github.com/iscale-llc/iscale-facebook-ad-builder)** - Open-source AI-powered Facebook ad platform covering competitor research, ad copy generation, image creation, and campaign management. Built with FastAPI + React.
 
 
 ### Phone Calls


### PR DESCRIPTION
Adds [Facebook Ad Builder](https://github.com/iscale-llc/iscale-facebook-ad-builder) to the Marketing AI Tools section.

An open-source, AI-powered Facebook ad automation platform that covers the full workflow: competitor research, ad copy generation, image creation, and campaign management. Built with FastAPI + React + Claude.

https://github.com/iscale-llc/iscale-facebook-ad-builder