### PR TITLE
Add LazyFish to Other AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Daruy](https://daruy.space/) - Personalized Gift Idea Generator
 - [Promptly](https://searchpromptly.com/) - Discover, create and share powerful prompts
 - [Melies](https://melies.co) - AI Filmmaking software
+- [LazyFish](https://lazyfish.app) - Client-side browser tools with AI chat (runs LLMs via WebGPU — no API keys, no server), file/video converter, and developer utilities. 100% local, zero data uploads.
 
 
 ## Learning resources


### PR DESCRIPTION
Adding [LazyFish](https://lazyfish.app) to the **Other** section.

LazyFish is a suite of client-side browser tools including AI chat (runs LLMs via WebGPU with no API keys or server), file/video converter, and developer utilities. Everything runs 100% in the browser with zero data uploads.