### PR TITLE
Add OpenTypeless to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [fabric](https://github.com/danielmiessler/fabric/) - Apply AI to everyday challenges in the comfort of your terminal. Help’s to get better results with tried and tested library of prompt pattern’s.
 - [Riffo](https://riffo.ai/) - An AI-powered file management tool for bulk renaming and automatic folder organization.
 - [SlidesWizard](https://slideswizard.io) - Create Presentations 10x faster. Generate PowerPoint and Google Slides presentations about any topic with AI
+- [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input for desktop. Press a hotkey, speak, and get AI-polished text typed into any app. Supports 6+ STT providers and multiple LLMs (GPT, Claude, Gemini, Ollama). MIT licensed, BYOK.
 - [Transgate](https://transgate.ai/) - AI Speech to Text
 - [RabbitHoles AI](https://www.rabbitholes.ai/) - Chat with AI on an Infinite Canvas
 - [Rember](https://www.rember.com/) - A simple yet powerful spaced repetition system designed to help you remember more.


### PR DESCRIPTION
- App name: OpenTypeless
- Category: Productivity
- License: MIT
- GitHub: https://github.com/tover0314-w/opentypeless

Open-source AI voice input for desktop. Press a global hotkey, speak, and get AI-polished text typed directly into any focused app. Supports 6+ STT providers (Whisper, Groq, Deepgram) and multiple LLMs (GPT, Claude, Gemini, Ollama). Fully BYOK, local API key storage, no copy-paste required.