### PR TITLE
Add OpenPaw to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [OpenPaw](https://github.com/daxaur/openpaw) - Open-source personal assistant wizard for Claude Code that adds 39+ skills including email, notes, smart home, focus mode, and task management. No daemon, no extra cost. #opensource
 
 
 ## Image


### PR DESCRIPTION
Hi! I'd like to add [OpenPaw](https://github.com/daxaur/openpaw) to the Code section.

**OpenPaw** is an open-source personal assistant wizard for Claude Code that adds 39+ skills (email, notes, smart home, focus mode, task dashboard, scheduling) through a single `npx pawmode` command. No daemon, no extra cost.

Thanks for maintaining this list!