### PR TITLE
Add Frostbyte API to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Frostbyte API](https://api-catalog-three.vercel.app) - Unified developer API gateway with 40+ tools — IP geolocation, web scraping, screenshots, DNS lookup, crypto prices, PDF generation, code execution, and more. Free tier with 200 credits. Includes a 13-tool MCP server for Claude, Cursor, and Windsurf.
 
 
 ## Code


### PR DESCRIPTION
## Summary

This PR adds [Frostbyte API](https://api-catalog-three.vercel.app) to the Developer tools section.

Frostbyte API is a unified developer API gateway offering:

- **40+ tools** in a single API: IP geolocation, web scraping, screenshots, DNS lookup, crypto prices, PDF generation, code execution, and more
- **Free tier** with 200 credits to get started
- **MCP server** with 13 tools for AI coding assistants (Claude, Cursor, Windsurf)
- Simple, consistent REST API with a single API key

It fits well in the Developer tools section alongside other developer-focused API platforms and tooling frameworks.