### PR TITLE
Add Product Manager Skills to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [Product Manager Skills](https://github.com/Digidai/product-manager-skills) - AI agent skill that turns Claude Code into an opinionated PM brain — 6 knowledge domains, 12 templates, 30+ frameworks, and 32 SaaS metrics with formulas. Install via `clawhub install product-manager-skills`.
 
 
 ### Meeting assistants


### PR DESCRIPTION
## Summary

- Adds **[Product Manager Skills](https://github.com/Digidai/product-manager-skills)** to the Productivity section
- An AI agent skill that turns Claude Code into an opinionated PM brain — 6 knowledge domains, 12 templates, 30+ frameworks, and 32 SaaS metrics with formulas
- Pure Markdown, zero scripts, zero dependencies. Install via `clawhub install product-manager-skills`

## Why it belongs here

Product Manager Skills is a productivity tool for product managers and founders who use AI agents. It ships structured PM knowledge (prioritization frameworks, metrics libraries, strategy templates) as an installable skill, making AI-assisted product work dramatically more effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)