### PR TITLE
Add flompt visual AI prompt builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Spell](https://spellapp.com) - Spell is the AI alternative to Google Docs
 - [Kosmik](https://www.kosmik.app) - AI moodboarding platform
 - [Magic Potion](https://www.magicpotion.app) - Visual AI Prompt Editor
+- [flompt](https://flompt.dev) - Visual AI prompt builder that decomposes prompts into 12 semantic blocks and compiles them into Claude-optimized XML. Free, open-source, browser extension for ChatGPT/Claude/Gemini.
 - [MinusX](https://minusx.ai/) - Have an AI Analyst answer all your data questions reliably on Metabase
 - [Excelmatic](https://excelmatic.ai) - AI-Powered Excel Data Analysis and Visualization, Skip the functions—just upload, chat, and watch your data turn into insights and visuals.
 - [Langfa.st](https://langfa.st/) - A fast, no-signup playground to test and share AI prompt templates


### PR DESCRIPTION
Adds [flompt](https://flompt.dev) to the Productivity section, next to other visual prompt tools like Magic Potion.

**What is flompt?**
- Visual prompt builder that decomposes any raw prompt into 12 semantic blocks (role, context, objective, constraints, examples, chain of thought, output format, etc.)
- Compiles blocks into Claude-optimized XML following Anthropic's best practices
- Browser extension that injects into ChatGPT, Claude, and Gemini toolbars
- Also available as an MCP server for Claude Code users

**Why it fits here:**
It sits next to "Magic Potion - Visual AI Prompt Editor" as another visual prompt tool, but with open-source, free, no-account access and cross-platform browser extension support.

**Links:**
- Web: https://flompt.dev
- GitHub: https://github.com/Nyrok/flompt (open-source)