### PR TITLE
docs: withdraw the stale LLMKit listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [gpt4all](https://github.com/nomic-ai/gpt4all) - A chatbot trained on a massive collection of clean assistant data including code, stories, and dialogue.
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.
 - [LlamaIndex](https://www.llamaindex.ai/) - A data framework for building LLM applications over external data.
+- [LLMKit](https://github.com/smigolsmigol/llmkit) - Open-source AI API gateway with cost tracking and budget enforcement for 11 LLM providers. TypeScript SDK, CLI, and MCP server. [#opensource](https://github.com/smigolsmigol/llmkit)
 - [Langfuse](https://langfuse.com/) - Open-source LLM engineering platform that helps teams collaboratively debug, analyze, and iterate on their LLM applications. [#opensource](https://github.com/langfuse/langfuse)
 - [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine-tune LLM, CV, and tabular models.
 - [Prediction Guard](https://www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.


### PR DESCRIPTION
## Status

Withdrawn.

## Reason

The product surface and public setup changed after this PR was opened, so the listing text is no longer a current merge candidate.

No maintainer action is requested.