### PR TITLE
Add Octo Terminal to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
+- [Octo Terminal](https://github.com/johunsang/octo-terminal-releases) - The ultimate vibe coding terminal. AI-powered all-in-one desktop app with built-in Claude, Codex, Ollama, split terminals, code editor, notes, SSH remote, and Telegram/Discord/Slack remote control. Built with Tauri + React + Rust.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.


### PR DESCRIPTION
## Add Octo Terminal

**Category:** Developer tools

[Octo Terminal](https://github.com/johunsang/octo-terminal-releases) is the ultimate vibe coding terminal — an AI-powered all-in-one desktop app for developers.

### Key Features
- **Built-in AI**: Claude, Codex, Ollama, Kimi — run multiple AI assistants side by side in split terminals
- **All-in-one**: Terminal + code editor (Monaco) + Markdown notes + built-in browser in a single window
- **Remote control**: Telegram, Discord, and Slack integration for remote terminal monitoring & commands
- **SSH remote**: Work on remote servers as if they were local, with PM2 server monitoring
- **75 themes**, split layouts, Kanban board, MCP server integration, voice input (Whisper)
- **Cross-platform**: macOS (Apple Silicon + Intel) and Windows
- **Tech stack**: Tauri v2 + React 19 + Rust + xterm.js

### Links
- GitHub: https://github.com/johunsang/octo-terminal-releases
- Download: https://github.com/johunsang/octo-terminal-releases/releases