### PR TITLE
Add LLMeter — open-source LLM cost monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.
 - [LlamaIndex](https://www.llamaindex.ai/) - A data framework for building LLM applications over external data.
 - [Langfuse](https://langfuse.com/) - Open-source LLM engineering platform that helps teams collaboratively debug, analyze, and iterate on their LLM applications. [#opensource](https://github.com/langfuse/langfuse)
+- [LLMeter](https://www.llmeter.org) - Open-source cost monitoring for LLM APIs. Track spending across OpenAI, Anthropic, DeepSeek, and OpenRouter in one dashboard with budget alerts. [#opensource](https://github.com/amedinat/LLMeter)
 - [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine-tune LLM, CV, and tabular models.
 - [Prediction Guard](https://www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.
 - [Portkey](https://portkey.ai/) - Full-stack LLMOps platform to monitor, manage, and improve LLM-based apps.


### PR DESCRIPTION
Adding [LLMeter](https://www.llmeter.org) to the **Developer tools** section.

LLMeter is an open-source cost monitoring platform for LLM APIs. It tracks spending across OpenAI, Anthropic, DeepSeek, and OpenRouter in a single dashboard with budget alerts.

- **Website:** https://www.llmeter.org
- **Source Code:** https://github.com/amedinat/LLMeter
- **License:** AGPL-3.0