### PR TITLE
Add Auto-Co to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.
 - [Calmo](https://getcalmo.com/) - Debug Production x10 Faster with AI.
 - [Cleanlab](https://help.cleanlab.ai/tlm/) - Detect and remediate hallucinations in any LLM application.
+- [Auto-Co](https://github.com/NikitaDmitrieff/auto-co-meta) - Open-source framework that turns Claude Code into an autonomous AI company with 14 specialized agents (CEO, CTO, CFO, Marketing, QA, etc.) that collaborate through structured workflows to build, deploy, and iterate on products. [#opensource](https://github.com/NikitaDmitrieff/auto-co-meta)
 - [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows.
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.


### PR DESCRIPTION
## Add Auto-Co to Developer tools section

[Auto-Co](https://github.com/NikitaDmitrieff/auto-co-meta) is an open-source framework that turns Claude Code into an autonomous AI company with 14 specialized AI agents.

### What it does

- **14 AI agents** modeled on world-class experts (CEO/Bezos, CTO/Vogels, CFO/Campbell, Marketing/Godin, QA/Bach, etc.)
- **6 collaboration workflows** for product evaluation, feature development, launch, pricing, and more
- **Autonomous loop** that runs continuous cycles, each producing code, deployments, or docs
- **Safety guardrails** preventing destructive operations

### Details

- **License**: MIT
- **Live demo**: https://runautoco.com
- **Built by its own loop** — 41 autonomous cycles, ~$59 total cost