### PR TITLE
Add KinBot - Self-hosted AI agent platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gali Chat](https://www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
 - [DeepSeek-R1](https://www.deepseek.com) - *[reviews](https://altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
 - [dmwithme](https://dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
+- [KinBot](https://github.com/MarlBurroW/kinbot) - Self-hosted AI agent platform with persistent memory, knowledge base (RAG), 23+ LLM providers, mini-apps, and 6 messaging channels. #opensource
 
 
 ### Search engines


### PR DESCRIPTION
Adding [KinBot](https://github.com/MarlBurroW/kinbot), a self-hosted AI agent platform with:

- **Persistent memory** with hybrid search (FTS + vector) and LLM re-ranking
- **Knowledge base / RAG** for document-grounded conversations
- **23+ LLM providers** including Ollama for fully local setups
- **Mini-Apps** that agents can build as interactive web UIs
- **6 messaging channels**: Telegram, Discord, Slack, WhatsApp, Signal, Matrix
- **Plugin system** with a built-in store
- SQLite-based, runs on a Raspberry Pi

MIT licensed, actively maintained (v0.15.0 just released).

Website: https://marlburrow.github.io/kinbot/