### PR TITLE
Add Calcstack to Graphic design section

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Text2Infographic](https://text2infographic.com/) - AI infographic generator and editor.
 - [Seede.ai](https://seede.ai/) - Create a stunning poster in just 1 minute with Seede.
 - [Magic Patterns](https://www.magicpatterns.com/) - AI-based UI builder with Figma export and React code generation.
+- [Calcstack](https://calcstack.co/) - AI-powered creative suite with diagram generator, circuit simulator, workflow builder, and mind map editor. Turn natural language into professional diagrams with 3 canvas engines (Excalidraw, React Flow, Draw.io).
 
 
 ### Image libraries


### PR DESCRIPTION
Add [Calcstack](https://calcstack.co/) to the Graphic design section. Calcstack is an AI-powered creative suite with a diagram generator, circuit simulator, workflow builder, and mind map editor. It turns natural language into professional diagrams using 3 canvas engines (Excalidraw, React Flow, Draw.io).