### PR TITLE
Add agentskill.sh to AI tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [LangMagic](https://easytolearn.io) - Learn languages from native content.
 - [fynk](https://fynk.com/) - AI powered contract management software
 - [LooksMax AI](https://looksmax.ai) - Find out how hot you are using AI
- 
+- [AgentSkill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
+
 
 ## Learning resources
 


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Other section.

agentskill.sh is a directory of 69,000+ AI agent skills with one-click install for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.