### PR TITLE
Add Beacon: semantic code search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI2sql](https://www.ai2sql.io/) - With AI2sql, engineers and non-engineers can easily write efficient, error-free SQL queries without knowing SQL.
 - [CodiumAI](https://www.codium.ai/) - With CodiumAI, you get non-trivial tests suggested right inside your IDE, so you stay confident when you push.
 - [PR-Agent](https://github.com/Codium-ai/pr-agent) - AI-powered tool for automated PR analysis, feedback, suggestions, and more.
+- [Beacon](https://github.com/sagarmk/beacon-plugin) - Semantic code search plugin for Claude Code using hybrid search with vector embeddings, BM25 keyword matching, and identifier boosting. Runs locally with Ollama, stores in SQLite.
 - [MutableAI](https://mutable.ai/) - AI Accelerated Software Development.
 - [TurboPilot](https://github.com/ravenscroftj/turbopilot) - A self-hosted copilot clone that uses the library behind llama.cpp to run the 6 billion parameter Salesforce Codegen model in 4 GB of RAM.
 - [GPT-Code UI](https://github.com/ricklamers/gpt-code-ui) - An open-source implementation of OpenAI's ChatGPT Code interpreter.


### PR DESCRIPTION
Adds [Beacon](https://github.com/sagarmk/beacon-plugin) to the Code section.

Beacon is a semantic code search plugin for Claude Code that uses hybrid search combining vector embeddings with BM25 keyword matching and identifier boosting. Indexes codebases locally via Ollama, stores everything in SQLite. Fully local by default, no API keys needed.