### PR TITLE
Add IteraTools - Pay-per-use API toolkit for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [IteraTools](https://api.iteratools.com) - Pay-per-use API toolkit for AI agents. 35+ tools via a single API: image generation, web scraping, TTS, OCR, QR codes, browser automation, DNS, sentiment analysis, and more. MCP-compatible, no signup required.
 
 
 ## Code


### PR DESCRIPTION
## Description

Adding [IteraTools](https://api.iteratools.com) to the **Developer tools** section.

**What it is:** IteraTools is a pay-per-use API platform with 35+ tools for AI agents and developers — accessible via a single API endpoint with no signup or subscription required.

**Why it fits here:**
- Designed specifically for AI agents (MCP-compatible)
- Covers image generation, web scraping, TTS, OCR, browser automation, DNS lookup, sentiment analysis, QR codes, and more
- Pay-per-use pricing via x402 micropayment protocol (fractions of a cent per call)
- REST API with OpenAPI spec — easy to integrate into any AI workflow

**Links:**
- 🌐 Site: https://iteratools.com
- 📖 Docs: https://api.iteratools.com/docs
- 🐙 GitHub: https://github.com/fredpsantos33/mcp-iteratools