### PR TITLE
Add Dorothy to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Runcell](https://runcell.dev) - AI Agent Extension for Jupyter Lab, Agent that can code, execute, analysis cell result, etc in Jupyter.
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
+- [Dorothy](https://github.com/Charlie85270/Dorothy) - Open-source desktop app to orchestrate multiple AI coding agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, and remote control.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
 
 


### PR DESCRIPTION
## Summary

- Adds [Dorothy](https://github.com/Charlie85270/Dorothy) to the **Code** section
- Dorothy is an open-source desktop app to orchestrate multiple AI coding agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, and remote control

## Details

- **Name:** Dorothy
- **URL:** https://github.com/Charlie85270/Dorothy
- **Category:** Code
- **Format:** Matches existing list entry format (`- [Name](URL) - Description.`)