### PR TITLE
Add models TUI to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [models](https://github.com/arimxyer/models) - A TUI for browsing AI models, benchmarks, and coding agents. Browse models from models.dev, compare benchmarks from Artificial Analysis, and track AI coding agents. [#opensource](https://github.com/arimxyer/models)
 
 
 ## Code


### PR DESCRIPTION
## Summary

- Adds [models](https://github.com/arimxyer/models) to the **Developer tools** section
- models is an open-source Rust TUI for browsing AI models (from models.dev), comparing benchmarks (from Artificial Analysis), and tracking AI coding agents with GitHub integration
- Available via `brew install models` or `cargo install modelsdev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)