### PR TITLE
Add Adgen to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[Adgen](https://tryadgen.com/)** - AI-powered bulk Meta ad creative generator. Produces 120+ image variations, ad copy in 35+ languages, and client review links from a single brief — built for ad agencies and media buyers.
 
 
 ### Phone Calls


### PR DESCRIPTION
## What's being added

**[Adgen](https://tryadgen.com/)** — AI-powered bulk Meta ad creative generator.

Adgen generates complete Meta ad campaigns from a single brief: 120+ image variations across formats, AI creative strategy (10 concepts), ad copy in 35+ languages, branded client review links, and direct Meta Ads Manager batch upload.

Built specifically for ad agencies and media buyers managing multiple clients — not a one-off creative tool.

- **Category:** Marketing AI Tools
- **Pricing:** Freemium (Free plan + paid from $19/mo)
- **Website:** https://tryadgen.com