### PR TITLE
Add Steel Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
+- [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and automation infrastructure for AI agents and apps with session-backed workflows, screenshots, PDFs, proxies, and anti-bot tooling.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.


### PR DESCRIPTION
This adds Steel Browser to the Developer tools section.

Steel Browser is an open-source browser sandbox and automation layer for AI agents and apps. It fits this section because it gives developers session-backed browser workflows, screenshots, PDFs, proxies, and anti-bot tooling for real web tasks.

Links:
- Repo: https://github.com/steel-dev/steel-browser
- CLI: https://github.com/steel-dev/cli
- Docs: https://docs.steel.dev/llms-full.txt
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: browser automation for dynamic websites with verifiable screenshot and PDF artifacts.