### PR TITLE
Add PM AI Partner: open-source AI plugin for Product Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [PM AI Partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework) - Open-source Claude Code plugin with 12 PM-specific agent skills, 6 workflow commands, and 3 automation hooks. Structured AI thinking partner for Product Managers. Install: `npx pm-ai-partner@latest`
 
 
 ## Image


### PR DESCRIPTION
## Summary

Adds [PM AI Partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework) to the **Code** section.

PM AI Partner is an open-source Claude Code plugin purpose-built for Product Managers. It provides:

- **12 agent skills** (thought partner, technical analyst, writer, devil's advocate, builder, data analyst, and more)
- **6 workflow commands** (product briefs, meeting prep, stakeholder updates, strategic clarity)
- **3 automation hooks** for seamless integration

**Install:** `npx pm-ai-partner@latest`

- GitHub: https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework
- npm: https://www.npmjs.com/package/pm-ai-partner