### PR TITLE
Add AI comparison tools across 7 categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gali Chat](https://www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
 - [DeepSeek-R1](https://www.deepseek.com) - *[reviews](https://altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
 - [dmwithme](https://dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
+- [AI Chatbot Compare](https://aichatbotcompare.com) - Compare 30+ AI chatbots side-by-side with features, pricing, and performance benchmarks.
 
 
 ### Search engines
@@ -121,6 +122,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [DeepL Write](https://www.deepl.com/write) - AI writing tool that improves written communication.
 - [Headlinesai.pro](https://www.headlinesai.pro/) - This AI powered tool can help you in generating catchy and optimized headlines based on your content for multiple platforms like Youtube, Medium, Indie Hackers and Reddit.
 - [GPTLocalhost](https://gptlocalhost.com/demo/) - A local Word Add-in for you to use local LLM servers in Microsoft Word. Alternative to "Copilot in Word" and completely local.
+- [AI Writing Compare](https://aiwritingcompare.com) - Compare 40+ AI writing tools with features, pricing, and quality benchmarks.
 
 
 ### ChatGPT extensions
@@ -302,6 +304,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [AI Coding Compare](https://aicodingcompare.com) - Compare 30+ AI coding assistants with features, pricing, and developer productivity benchmarks.
 
 
 ## Image
@@ -355,6 +358,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI Photo Forge](https://aiphotoforge.com/) - A Telegram bot to generate AI pictures of you.
 - [AI Boost](https://boost.pictures/) - All-in-one service for creating and editing images with AI: upscale images, swap faces, generate new visuals and avatars, try on outfits, reshape body contours, change backgrounds, retouch faces, and even test out tattoos.
 - [PlantTattoosAI](https://www.planttattoosai.com/) - Plant and flower tattoos designs generator trained on real botanicals.
+- [AI Image Compare](https://aiimagecompare.com) - Compare 25+ AI image generators with features, pricing, and visual quality benchmarks.
 
 
 
@@ -402,6 +406,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
 - [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
 - [Sisif](https://sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
+- [AI Video Compare](https://aivideocompare.com) - Compare 20+ AI video generators with features, pricing, and output quality benchmarks.
 
 
 ### Animation
@@ -464,6 +469,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[AI Marketing Compare](https://aimarketingcompare.com)** - Compare 30+ AI marketing tools with features, pricing, and ROI benchmarks.
 
 
 ### Phone Calls
@@ -545,6 +551,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Daruy](https://daruy.space/) - Personalized Gift Idea Generator
 - [Promptly](https://searchpromptly.com/) - Discover, create and share powerful prompts
 - [Melies](https://melies.co) - AI Filmmaking software
+- [AI Business Compare](https://aibusinesscompare.com) - Compare 30+ AI business tools with features, pricing, and productivity benchmarks.
 
 
 ## Learning resources


### PR DESCRIPTION
## Summary

Adds 7 AI comparison tool entries to their respective existing sections:

- **Chatbots**: [AI Chatbot Compare](https://aichatbotcompare.com) - Compare 30+ AI chatbots
- **Writing assistants**: [AI Writing Compare](https://aiwritingcompare.com) - Compare 40+ AI writing tools
- **Code**: [AI Coding Compare](https://aicodingcompare.com) - Compare 30+ AI coding assistants
- **Image > Services**: [AI Image Compare](https://aiimagecompare.com) - Compare 25+ AI image generators
- **Video**: [AI Video Compare](https://aivideocompare.com) - Compare 20+ AI video generators
- **Marketing AI Tools**: [AI Marketing Compare](https://aimarketingcompare.com) - Compare 30+ AI marketing tools
- **Other**: [AI Business Compare](https://aibusinesscompare.com) - Compare 30+ AI business tools

Each tool provides side-by-side comparisons with features, pricing, and performance benchmarks to help users choose the right AI tool for their needs.

Entries follow existing formatting conventions for each section.