### PR TITLE
Add Enconvo - AI Agent Launcher for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [MindStudio](https://mindstudio.ai/) — Build powerful AI Agents for yourself, your team, or your enterprise. Powerful, easy to use, visual builder—no coding required, but extensible with code if you need it. Over 100 templates for all kinds of business and personal use cases.
 - [Daruy](https://daruy.space/) - Personalized Gift Idea Generator
 - [Promptly](https://searchpromptly.com/) - Discover, create and share powerful prompts
+- [Enconvo](https://enconvo.com) - AI Agent Launcher for macOS. The always-online AI companion that knows you best. Context-aware AI assistant with SmartBar, PopBar, voice input, live captions, TTS, knowledge base, custom workflows, 100+ plugins. macOS 14+ required.
 - [Melies](https://melies.co) - AI Filmmaking software
 
 


### PR DESCRIPTION
## Add Enconvo

[Enconvo](https://enconvo.com) is an AI Agent Launcher for macOS — the always-online AI companion that knows you best. It provides a context-aware AI assistant with SmartBar, PopBar, voice input, live captions, TTS, knowledge base, custom workflows, and 100+ plugins. Requires macOS 14+.

Added to the **Other** section following the existing entry format.