### PR TITLE
Add EVC Spark MCP to Developer tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
 
+- [EVC Spark MCP](https://github.com/entire-vc/evc-spark-mcp) - MCP server for discovering, searching, and installing curated AI agent workflows from the Spark catalog. Search 200+ MCP servers, get install configs, browse curated bundles.
 
 ## Code
 


### PR DESCRIPTION
Adding [EVC Spark MCP](https://github.com/entire-vc/evc-spark-mcp) to the Developer tools section.

**What it does:** MCP server for discovering, searching, and installing curated AI agent workflows from the Spark catalog. Search 200+ MCP servers, get ready-to-use install configs, and browse curated bundles of skills, prompts, and integrations.

- npm: `evc-spark-mcp`
- GitHub: https://github.com/entire-vc/evc-spark-mcp