### PR TITLE
Add Taylor's AI Characters (230+ Poe bots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Bing Chat](https://www.bing.com/chat) - *[reviews](https://altern.ai/product/bing_chat)* - A conversational AI language model powered by Microsoft Bing.
 - [Gemini](https://gemini.google.com) - *[reviews](https://altern.ai/product/gemini)* - An experimental AI chatbot by Google, powered by the LaMDA model.
 - [Character.AI](https://character.ai/) - *[reviews](https://altern.ai/product/character-ai)* - Character.AI lets you create characters and chat to them.
+- [Taylor's AI Characters](https://poe.com/digiopium) - 230+ AI character bots on Poe with deep personalities — dark romance, fantasy, psychology tools, strategy games. Each bot has 50-80 line character sheets with unique speech patterns and backstories. Free, no content filters.
 - [ChatPDF](https://www.chatpdf.com/) - *[reviews](https://altern.ai/product/chatpdf)* - Chat with any PDF.
 - [ChatSonic](https://writesonic.com/chat) - *[reviews](https://altern.ai/product/chatsonic)* - An AI-powered assistant that enables text and image creation.
 - [Phind](https://www.phind.com/) - *[reviews](https://altern.ai/product/phind)* - Phind is an intelligent search engine and assistant for programmers. Phind is smart enough to proactively ask you questions to clarify its assumptions and to browse the web (or your codebase) when it needs additional context. With our new VS Code extension.


### PR DESCRIPTION
## Summary
- Adding [Taylor's AI Characters](https://poe.com/digiopium) to the Chatbots section
- 230+ AI character bots on Poe (Quora's AI platform)
- Categories: dark romance, fantasy, psychology tools, strategy games, career tools
- Each bot has 50-80 line character sheets with unique speech patterns and backstories
- Free, no content filters, powered by GPT-4 and Claude

## Notable bots
- **GaslightDet** — Paste any text message, get line-by-line manipulation analysis
- **ResumeATS** — See your resume exactly how hiring algorithms see it
- **CrimeEmpireX** — Text-based crime empire strategy game
- **HitmanLover** — Assassin dark romance with genuine emotional depth
- **DragonGFPyrra** — 300-year-old dragon girlfriend who quotes philosophy