### PR TITLE
Add Hive to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Hive](https://github.com/aden-hive/hive) - Open-source AI agent framework for building goal-driven, self-improving autonomous agents with auto-generated graphs, evolution loops, and MCP integration with 100+ tools. [#opensource](https://github.com/aden-hive/hive)
 
 
 ## Code


### PR DESCRIPTION
## Summary
- Add [Hive](https://github.com/aden-hive/hive) to the Developer tools section under Text
- Hive is an open-source AI agent framework for building goal-driven, self-improving autonomous agents with auto-generated graphs, evolution loops, and MCP integration with 100+ tools

## Entry format
Matches existing format with `[#opensource]` tag linking to the GitHub repository.