### PR TITLE
Add DriftWatch: open-source LLM behavioural drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [DriftWatch](https://genesisclawbot.github.io/llm-drift/) - Open-source LLM behavioural drift detection. Continuously monitors GPT-4o, Claude, and Gemini for silent model updates that break your prompts — before users report issues. [#opensource](https://github.com/GenesisClawbot/llm-drift)
 
 
 ## Code


### PR DESCRIPTION
## What this adds

**[DriftWatch](https://github.com/GenesisClawbot/llm-drift)** — Open-source LLM behavioural drift detection

Placed in **Developer tools** alongside Langfuse, Phoenix, Portkey, Agenta (all LLM observability/monitoring tools).

## Why it belongs here

- **Category fit**: LLM observability & monitoring (same as Langfuse, Phoenix, Portkey, Agenta already listed)
- **MIT License** ✅
- **Open-source** ✅ ([github.com/GenesisClawbot/llm-drift](https://github.com/GenesisClawbot/llm-drift))
- **Unique value**: Drift detection specifically — catches silent model behavior changes before users notice (the Feb 10, 2025 GPT-4o update caused widespread silent failures; DriftWatch catches events like this automatically)

## What it does

Continuously runs test prompts against LLM APIs (GPT-4o, Claude, Gemini) and scores behavioral drift vs baseline. Alerts teams when responses change unexpectedly — format violations, instruction-following regression, output length shifts.

Free tier: 3 prompts monitored | Paid: £99/mo Starter
