### PR TITLE
Add Greywall

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Greywall](https://github.com/GreyhavenHQ/greywall) - Deny-by-default sandbox for AI coding agents with filesystem isolation, network control, and built-in profiles for agents like Claude Code or OpenCode. [#opensource](https://github.com/GreyhavenHQ/greywall)
 
 
 ## Code


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** Greywall
- **Description:** Deny-by-default sandbox for AI coding agents with filesystem isolation and network control.
- **Tool URL:** https://github.com/GreyhavenHQ/greywall
- **Altern.ai page link:** N/A

## 📌 Description
Adding Greywall to the Developer tools section. It provides OS-level sandboxing for AI coding agents with built-in profiles for agents like Claude Code or OpenCode. Supports Linux (bubblewrap + seccomp/Landlock/eBPF) and macOS (sandbox-exec Seatbelt profiles).

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [ ] 📚 Documentation / README update
- [x] ➕ Adding a new AI tool
- [ ] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix
- [ ] Other (please specify):

---

## 📷 Screenshots / Demo (if applicable)
N/A

---

## 💡 Additional Notes
Greywall is an open-source deny-by-default command sandbox that wraps AI coding agents with restricted filesystem access and transparent network redirection. It includes built-in agent profiles for Claude Code, OpenCode, Aider, and Codex CLI.