### PR TITLE
Add Humanizer AI to writing assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Jenni](https://jenni.ai/) - Jenni is the ultimate writing assistant that saves you hours of ideation and writing time.
 - [LAIKA](https://www.writewithlaika.com/) - LAIKA trains an artificial intelligence on your own writing to create a personalised creative partner-in-crime.
 - [QuillBot](https://quillbot.com) - AI-powered paraphrasing tool.
+- [Humanizer AI](https://humanizerai.com) - AI text humanizer and detector that transforms AI-generated content into natural writing that bypasses GPTZero, Turnitin, and Originality.ai.
 - [Postwise](https://postwise.ai/) - Write tweets, schedule posts and grow your following using AI.
 - [Copysmith](https://copysmith.ai/) - AI content creation solution for Enterprise & eCommerce.
 - [Yomu](https://www.yomu.ai) - AI writing assistant for students and academics.


### PR DESCRIPTION
Adding [Humanizer AI](https://humanizerai.com) to the Writing assistants section.

Humanizer AI is an AI text humanizer and detector that transforms AI-generated content into natural writing that bypasses detection tools like GPTZero, Turnitin, and Originality.ai. Free tier available with paid plans from $10/month.