### PR TITLE
Add Lacy Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Lacy Shell](https://github.com/lacymorrow/lacy) - Shell plugin that auto-routes natural language to AI coding agents (Claude Code, Gemini, OpenCode, Codex). Real-time color indicator, sub-millisecond lexical detection. [#opensource](https://github.com/lacymorrow/lacy)
 
 
 ## Code


### PR DESCRIPTION
Adds [Lacy Shell](https://github.com/lacymorrow/lacy) to the Developer tools section.

Lacy.sh is a shell plugin that auto-routes natural language to AI coding agents (Claude Code, Gemini CLI, OpenCode, Codex). It uses sub-millisecond lexical detection — no AI call to classify input. Real-time color indicator shows routing before you press enter.

- Open source, [MIT licensed](https://github.com/lacymorrow/lacy/blob/main/LICENSE)
- Works with ZSH and Bash 4+ on macOS, Linux, and WSL