### PR TITLE
Add Signbee - Document signing API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Signbee](https://signb.ee) - Document signing API for AI agents. Send contracts for e-signature with email OTP verification and SHA-256 signing certificates. Supports MCP, Agent Skills, and direct API.
 
 
 ## Code


### PR DESCRIPTION
Adds [Signbee](https://signb.ee) to the Developer tools section.

Signbee is a document signing API that lets AI agents send contracts for e-signature. It supports MCP, Agent Skills, and direct API integration.

- **npm**: https://www.npmjs.com/package/signbee-mcp
- **GitHub**: https://github.com/signbee/mcp
- **Website**: https://signb.ee