### PR TITLE
Add WritBase to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [SinglebaseCloud](https://singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.
 - [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
 - [Wordware](https://www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
+- [WritBase](https://github.com/Writbase/writbase) - MCP-native task management control plane for AI agent fleets with multi-agent permissions and full provenance.
 - [CodeRabbit](https://coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)


### PR DESCRIPTION
## Summary
- Adds [WritBase](https://github.com/Writbase/writbase) to the Productivity section
- WritBase is an MCP-native task management control plane for AI agent fleets with multi-agent permissions and full provenance

## Entry
Inserted alphabetically in the Productivity section after Wordware.