### PR TITLE
Add iGPT to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [iGPT](https://igpt.ai/) - Email Intelligence API that converts unstructured email threads and attachments into structured, reasoning-ready JSON for AI agents and workflows. Returns contextual understanding, decisions, commitments, participants, action items, not just raw email data.
 
 
 ## Code


### PR DESCRIPTION
## 📂 New Tool Information
- **Tool Name:** iGPT
- **Description:** Email Intelligence API that converts unstructured email threads into structured, reasoning-ready JSON for AI agents and workflows.
- **Tool URL:** https://www.igpt.ai/
- **Altern.ai page link:** (not available)

## 📌 Description
Added iGPT to the Developer tools section. iGPT gives AI agents contextual understanding of email conversations — decisions, commitments, participants, action items via a simple API call. Python and Node.js SDKs available on PyPI and npm.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**