### PR TITLE
Add KeepRule - AI Investment Discipline Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Scenario](https://www.scenario.com/) - AI-generated gaming assets.
 - [Teleprompter](https://github.com/danielgross/teleprompter) - An on-device AI for your meetings that listens to you and makes charismatic quote suggestions.
 - [FinChat](https://finchat.io/) - Using AI, FinChat generates answers to questions about public companies and investors.
+- [KeepRule](https://keeprule.com/) - AI-powered investment principles platform curating wisdom from 26+ legendary investors (Buffett, Munger, Dalio, Lynch, Marks) with AI scenario analysis for systematic investment decision-making.
 - [Petals](https://github.com/bigscience-workshop/petals) - BitTorrent style platform for running AI models in a distributed way.
 - [Shotstack Workflows](https://shotstack.io/product/workflows/) - No-code, automation workflow tool for building Generative AI media applications.
 - [Aispect](https://aispect.io/?ref=mahseema-awesome-ai-tools) - New way to experience events.


### PR DESCRIPTION
## Summary

- Adds [KeepRule](https://keeprule.com) to the **Other** section, next to FinChat (another finance AI tool)
- KeepRule is an AI-powered investment discipline tracking platform with principles from 26 legendary investors (Buffett, Munger, Dalio, etc.), scenario analysis, and psychological tests

## Why it fits this list

KeepRule applies AI to investment discipline and behavioral finance -- a unique use case that complements the existing finance tools (FinChat, Morpher AI) already featured in this list. It uses AI to analyze investment scenarios against proven principles and provides psychological assessments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)