### PR TITLE
Add onUI - UI Annotation Tool for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [onUI](https://github.com/onllm-dev/onUI) - Open-source browser extension and MCP server for annotation-first UI pair programming with AI agents. Annotate, draw, and capture UI context from any webpage for Claude Code, Cursor, Windsurf, and Copilot. [#opensource](https://github.com/onllm-dev/onUI)
 
 
 ## Image


### PR DESCRIPTION
## Summary

- Adds [onUI](https://github.com/onllm-dev/onUI) to the **Code** section
- onUI is an open-source (GPL-3.0) browser extension and MCP server for annotation-first UI pair programming with AI agents
- It lets users annotate, draw, and capture UI context from any webpage for use with Claude Code, Cursor, Windsurf, and Copilot

## Details

- **Name:** onUI
- **URL:** https://github.com/onllm-dev/onUI
- **License:** GPL-3.0 (free, open source)
- **Category:** Code