### PR TITLE
Add Rank4AI to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[Rank4AI](https://rank4ai.co.uk)** - AI search visibility platform for optimizing brand recommendations across ChatGPT, Gemini, Perplexity and Google AI Overviews
 
 
 ### Phone Calls


### PR DESCRIPTION
## Summary

- Adds [Rank4AI](https://rank4ai.co.uk) to the "Marketing AI Tools" section

Rank4AI is an AI search visibility platform that helps businesses optimise how they appear in AI-generated recommendations across ChatGPT, Gemini, Perplexity and Google AI Overviews. It uses a proprietary methodology focused on generative engine optimization (GEO) rather than traditional keyword rankings.

**Website:** https://rank4ai.co.uk