### PR TITLE
Add FlyDex to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [FlyDex](https://flydex.net) - Browser-first control plane for operating local Codex sessions from phone or browser, with QR pairing, approvals, and machine continuity.
 
 
 ## Code


### PR DESCRIPTION
## Summary
- add FlyDex to the Developer tools section
- describe it as a browser-first control plane for local Codex sessions

## Why it fits
FlyDex is a public developer tool for operating local Codex workflows from phone or browser with QR pairing, approvals, and continuity.

## Validation
- added a single list entry in the Developer tools section