### PR TITLE
Add Arch Tools — 61-tool API platform for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click. 
 - [StarOps](https://ingenimax.ai) - AI Platform Engineer
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
+- [Arch Tools](https://archtools.dev) - 58+ API tools behind one key and MCP server. Web scraping, AI generation (Claude/GPT-4/Grok/Gemini), screenshots, image gen, crypto data, and more. Supports x402 USDC payments and BYOK. [#opensource](https://github.com/Deesmo/Arch-AI-Tools)
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)


### PR DESCRIPTION
## Add Arch Tools

[Arch Tools](https://archtools.dev) is a unified API platform offering 58 production-ready tools behind a single API key.

### Key Features:
- **MCP Native** — Works as a Model Context Protocol server for AI agents
- **x402 Payments** — USDC payments on 15 blockchain networks via Coinbase x402 protocol
- **58 Tools** — Web scraping, AI generation, crypto, voice, email, and more
- **Single API Key** — One key for all tools

### Links:
- Website: https://archtools.dev
- GitHub: https://github.com/Deesmo/Arch-AI-Tools
- MCP Registry: Listed on MCP Registry, PulseMCP, Glama, and more
