### PR TITLE
add Louisa AI-powered release notes bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [Louisa](https://github.com/arthur-ai/louisa) - AI-powered release notes bot for GitHub and GitLab that auto-generates polished, user-facing release notes when you push a tag.
 
 
 ## Image


### PR DESCRIPTION
## Tool name
Louisa

## Description
AI-powered release notes bot for GitHub and GitLab that auto-generates polished, user-facing release notes when you push a tag.

## URL
https://github.com/arthur-ai/louisa

## Category
Developer tools

## Why it belongs here
Louisa uses the Anthropic Claude SDK to analyze commits and pull/merge requests between tags and generate structured, user-facing release notes — automatically published to your GitHub or GitLab Releases page on every tag push. It fits naturally alongside tools like PR-Agent and Gito in the Developer Tools section.

- Open source (MIT), actively maintained
- Works with GitHub, GitLab, or both simultaneously
- Optional GitHub Actions pipelines for monthly blog drafting and changelog publishing to readme.io
- Zero-config after setup: push a tag, release notes appear