### PR TITLE
Add ORCH — CLI orchestrator for AI agent teams (Code section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [ORCH](https://github.com/oxgeneral/ORCH) - CLI orchestrator for running Claude Code, Codex, and Cursor as a coordinated AI agent team. State machine, TUI dashboard, MIT. #opensource
 
 
 ## Image


### PR DESCRIPTION
## What is ORCH?

[ORCH](https://github.com/oxgeneral/ORCH) is an open-source CLI orchestrator that turns Claude Code, OpenAI Codex, and Cursor into a **coordinated AI agent team** — not just parallel runners.

## Why it fits the Code section

- **CLI tool** for developers managing multiple AI coding agents
- Works with the most popular AI coding tools already listed here (GitHub Copilot, OpenAI Codex, Amazon Q)
- MIT licensed, open-source, available on npm (`@oxgeneral/orch`)
- TypeScript-strict, 1493+ tests

## Key features

- **State machine lifecycle**: `todo → in_progress → review → done` with mandatory review gate
- **Auto-retry**: failed agents automatically recover with `retrying` state
- **Inter-agent messaging**: agents communicate and share context
- **TUI dashboard**: real-time Ink/React terminal UI
- **Multi-adapter**: Claude Code, OpenAI Codex, Cursor, OpenCode, shell

## Entry added

```
- [ORCH](https://github.com/oxgeneral/ORCH) - CLI orchestrator for running Claude Code, Codex, and Cursor as a coordinated AI agent team. State machine, TUI dashboard, MIT. #opensource
```

Added at the end of the `## Code` section, consistent with existing entry format.