### PR TITLE
Add AgentRank — ranked MCP server discovery index

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [AgentRank](https://agentrank-ai.com) - Live-scored index of 25,000+ MCP servers and agent tools, ranked daily by real GitHub maintenance signals. Find actively maintained tools for AI development. Free.
 
 
 ## Image


### PR DESCRIPTION
Adds [AgentRank](https://agentrank-ai.com) to the **Code** section.

AgentRank is a live-scored index of 25,000+ MCP servers and agent tools for AI development. It crawls GitHub nightly and ranks tools by real maintenance signals — freshness (days since last commit), issue health (closed/total ratio), contributors, dependents, and stars.

The problem it solves: AI tools recommend MCP servers from training data, but that data goes stale. AgentRank shows what's actually maintained right now.

- **Website:** https://agentrank-ai.com
- **GitHub:** https://github.com/superlowburn/agentrank
- **Free:** Yes, no signup required
- **MCP server install:** `npx -y agentrank-mcp-server`