### PR TITLE
Add Fazm - AI computer agent for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Notion AI](https://www.notion.so/product/ai) - Write better, more efficient notes and docs.
 - [Nekton AI](https://nekton.ai) - Automate your workflows with AI. Describe your workflows step by step in plain language.
 - [Elephas](https://elephas.app/?ref=mahseema-awesome-ai-tools) - Personal AI writing assistant for the Mac.
+- [Fazm](https://fazm.ai/) - Voice-first AI computer agent for macOS. Controls your entire desktop - clicking, typing, navigating browsers, writing code. Open source and local-first.
 - [Lemmy](https://lemmy.co/?ref=mahseema-awesome-ai-tools) - Autonomous AI Assistant for Work.
 - [Google Sheets Formula Generator](https://bettersheets.co/google-sheets-formula-generator?ref=mahseema-awesome-ai-tools) - Forget about frustrating formulas in Google Sheets.
 - [CreateEasily](https://createeasily.com/?ref=mahseema-awesome-ai-tools) - Free speech-to-text tool for content creators that accurately transcribes audio & video files up to 2GB.


### PR DESCRIPTION
## Addition

Added [Fazm](https://fazm.ai/) to the **Productivity** section.

Fazm is a voice-first, open-source AI computer agent for macOS. It controls your entire desktop - clicking, typing, navigating browsers, writing code. Local-first architecture with on-device processing.

- Website: https://fazm.ai
- GitHub: https://github.com/m13v/fazm
- License: MIT