### PR TITLE
Add affiliate-skills — 45 AI agent skills for affiliate marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[affiliate-skills](https://github.com/Affitor/affiliate-skills)** - 45 AI-powered skills that turn any AI into an affiliate marketing team. Research programs, write content, build landing pages, deploy, track, optimize. Open source, MIT licensed.
 
 
 ### Phone Calls


### PR DESCRIPTION
## Add affiliate-skills

**Repository:** https://github.com/Affitor/affiliate-skills
**License:** MIT
**Skills:** 45
**Standard:** [agentskills.io](https://agentskills.io)

### What it is

45 open-source AI agent skills for affiliate marketing. Full funnel: research, content, SEO, landing pages, distribution, analytics, automation. Works with Claude Code, ChatGPT, Gemini, Cursor, Windsurf.

### Compatibility

Claude Code, ChatGPT, Gemini CLI, Cursor, Windsurf, OpenClaw, any AI agent.

### Install

```bash
npx skills add Affitor/affiliate-skills
```

### Why include it

- Largest open-source affiliate marketing skill collection (45 skills)
- Follows agentskills.io standard
- Full funnel coverage (8 stages with closed-loop flywheel)
- Works across all major AI coding agents
- Active development, MIT licensed