### PR TITLE
Add headcount.ai to Related Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Awesome Workflow Automation](https://github.com/dariubs/awesome-workflow-automation) - Curated List of Workflow Automation Apps And Tools
 - [Awesome Marketing](https://github.com/marketingtoolslist/awesome-marketing)
 - [Top AI Directories](https://github.com/best-of-ai/ai-directories) - An awesome list of best top AI directories to submit your ai tools
+- [Headcount](https://headcount.ai) - Guides and tools for running a one-person AI business
 
 
 created by [Mahsima Dastan](https://github.com/mahseema)


### PR DESCRIPTION
## What this adds

Adds [Headcount](https://headcount.ai) to the Related Awesome Lists section.

Headcount is a free resource site with guides and tools for running a one-person AI business. It covers AI agent stacks, automation strategies, delegation frameworks, and emerging patterns from solopreneurs using AI to run entire departments.

It fits alongside the existing productivity and workflow automation entries in the Related Awesome Lists section.

## Checklist
- [x] Link is to a working URL
- [x] Description is concise and accurate
- [x] Follows the existing format of the list