### PR TITLE
Add Creator Skills to Other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Taranify](https://www.taranify.com) - Using AI, Taranify finds you Spotify playlists, Netflix shows, Books & Foods you'd enjoy when you don't exactly know what you want. 
 - [Diagram](https://diagram.com/) - Magical new ways to design products.
 - [PromptBase](https://promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.
+- [Creator Skills](https://creatorskills.co/) - Marketplace of ready-to-use AI workflow skills for content creators, with installable systems for YouTube, podcasting, repurposing, analytics, and monetization across Claude, ChatGPT, Cursor, and Claude Code.
 - [This Image Does Not Exist](https://thisimagedoesnotexist.com/) - Test your ability to tell if an image is human or computer generated.
 - [Have I Been Trained?](https://haveibeentrained.com/) - Check if your image has been used to train popular AI art models.
 - [AI Dungeon](https://aidungeon.io/) - A text-based adventure-story game you direct (and star in) while the AI brings it to life.


### PR DESCRIPTION
Adds Creator Skills to the Other section.

Creator Skills is a marketplace of ready-to-use AI workflow skills for content creators, including systems for YouTube, podcasting, repurposing, analytics, and monetization across Claude, ChatGPT, Cursor, and Claude Code.