### PR TITLE
Add kimi-k-cli: self-improving terminal AI coding assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
+- [kimi-k-cli](https://github.com/suebi76/kimi-k-cli) - Self-improving terminal AI coding assistant powered by Kimi K2.5. 11 built-in tools (bash, file ops, web search, memory), plugin system, and self-improvement capability.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.


### PR DESCRIPTION
## Addition

Adding [kimi-k-cli](https://github.com/suebi76/kimi-k-cli) to the list of AI tools.

**kimi-k-cli** is a self-improving terminal AI coding assistant powered by Moonshot AI's Kimi K2.5 via NVIDIA NIM API.

### Why it belongs here
- Open source (MIT license)
- Terminal-based AI coding assistant with 11 built-in tools
- Unique self-improvement capability (can edit its own source code)
- Plugin system for community extensions
- Free API access via NVIDIA NIM

### Category
Added next to other terminal/CLI AI tools (Plandex, fabric, etc.)