### PR TITLE
Add DialCatch — AI phone assistant for solo tradespeople

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AICaller.io](https://aicaller.io/?ref=v) - AICaller is a simple-to-use automated bulk calling solution that uses the latest Generative AI technology to trigger phone calls for you and get things done. It can do things like lead qualification, data gathering over phone calls, and much more. It comes with a powerful API, low cost pricing and free trial.
 - [AI Voice Agents](https://diallink.com/) — AI Voice Agents for business calls and routine tasks, powered by DialLink cloud phone system.
 - [Cald.ai](https://cald.ai) - AI based calling agents for outbound and inbound phone calls.
+- [DialCatch](https://dialcatch.com/) - AI phone assistant built for solo tradespeople (plumbers, electricians, HVAC). Answers missed calls 24/7, qualifies leads, and texts you the details. $29/mo.
 - [Rosie](https://heyrosie.com/) - AI Phone Answering Service
 
 ### Speech


### PR DESCRIPTION
Adding [DialCatch](https://dialcatch.com/) to the **Phone Calls** section.

**What it does:** DialCatch is an AI phone answering assistant built specifically for solo tradespeople — plumbers, electricians, HVAC techs, handymen, and roofers. It answers missed calls 24/7, qualifies leads using trade-specific AI conversations, and texts the details to the tradesperson's phone.

**Why it fits this list:** It's a specialized AI phone call agent for the trades vertical, filling a gap between generic AI receptionists and the needs of one-person trade shops.

**Website:** https://dialcatch.com  
**Live demo line:** Call 402-961-3337 to talk to the AI