### PR TITLE
Add Promptzy — native macOS AI prompt manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [MindPal](https://mindpal.space/) - Build your AI Second Brain with a team of AI agents and multi-agent workflow
 - [fabric](https://github.com/danielmiessler/fabric/) - Apply AI to everyday challenges in the comfort of your terminal. Help’s to get better results with tried and tested library of prompt pattern’s.
 - [Riffo](https://riffo.ai/) - An AI-powered file management tool for bulk renaming and automatic folder organization.
+- [Promptzy](https://promptzy.app) - Native macOS AI prompt manager with Cmd+Shift+P global launcher. Store prompts as Markdown, use dynamic tokens like {{clipboard}} and {{date}}, and paste into any AI app in under 2 seconds. Free + $5 one-time Pro.
 - [SlidesWizard](https://slideswizard.io) - Create Presentations 10x faster. Generate PowerPoint and Google Slides presentations about any topic with AI
 - [Transgate](https://transgate.ai/) - AI Speech to Text
 - [RabbitHoles AI](https://www.rabbitholes.ai/) - Chat with AI on an Infinite Canvas


### PR DESCRIPTION
Promptzy is a native macOS app for managing AI prompts. Press Cmd+Shift+P from anywhere to instantly search and paste any saved prompt into ChatGPT, Claude, Cursor, or any other app. Prompts are stored as plain Markdown files (no lock-in). Supports dynamic tokens like `{{clipboard}}` and `{{date}}`.

https://promptzy.app

Fits in the Productivity section.