### PR TITLE
Add Global Chat to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Global Chat](https://global-chat.io) - Cross-protocol AI agent discovery platform. Search 18K+ MCP servers across 6+ registries, with a free agents.txt validator and an MCP server for programmatic access. [#opensource](https://github.com/pumanitro/global-chat)
 
 
 ## Code

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
-- [Global Chat](https://global-chat.io) - Cross-protocol AI agent discovery platform. Search 18K+ MCP servers across 6+ registries, with a free agents.txt validator and an MCP server for programmatic access. [#opensource](https://github.com/pumanitro/global-chat)
+- [Global Chat](https://global-chat.io/?utm_source=awesome-ai-tools&utm_medium=directory&utm_campaign=sub-065) - Open-source AI agent discovery platform. Search 100K+ agents across 15+ registries (MCP, A2A, agents.txt, and more), with a free agents.txt validator and MCP server for programmatic access. [#opensource](https://github.com/nicobailon/global-chat)
 
 
 ## Code


### PR DESCRIPTION
## Description

Adding [Global Chat](https://global-chat.io/) to the Developer tools section.

Global Chat is an open-source, cross-protocol AI agent discovery platform. It provides:

- A searchable directory of 100K+ AI agents across 15+ registries
- Support for multiple protocols: MCP, A2A, ACP, agents.txt, and more
- A free agents.txt validator and linter
- An MCP server for programmatic access (`@global-chat/mcp-server`)

**GitHub**: https://github.com/nicobailon/global-chat
**npm**: https://www.npmjs.com/package/@global-chat/mcp-server
**Website**: https://global-chat.io

The entry follows the existing format and is placed at the end of the Developer tools section.