### PR TITLE
Add Azex Speech to Speech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Bark](https://github.com/suno-ai/bark) - A transformer-based text-to-audio model. #opensource
 - [CustomPod.io](https://custompod.io) - Generate daily news podcasts only on the topics you care about.
 - [EKHOS AI](https://ekhos.ai) - An AI speech-to-text software with powerful proofreading features. Transcribe most audio or video files with real-time recording and transcription.
-  
+- [Azex Speech](https://github.com/azex-ai/speech) - Mac native voice input tool for Crypto & AI professionals. Local ASR with FireRedASR, 1800+ domain terms, pronunciation training. Open source.
+
 ### Music
 
 - [Harmonai](https://www.harmonai.org/) - We are a community-driven organization releasing open-source generative audio tools to make music production more accessible and fun for everyone.


### PR DESCRIPTION
## What's being added

[Azex Speech](https://github.com/azex-ai/speech) — Mac native voice input tool for Crypto & AI professionals.

## Why it fits

- **Local AI speech recognition**: Uses FireRedASR, no cloud dependency
- **Domain-specific**: 1800+ Crypto and AI/programming terms built in
- **Open source**: Apache/MIT licensed, Swift/SwiftUI
- **Unique positioning**: Pronunciation training and implicit learning from user corrections

## Placement

Added at the end of the existing **Speech** section under Audio, following the same format as other entries.