### PR TITLE
Add Rapid-MLX to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 ### Developer tools
 
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
+- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) - OpenAI-compatible local LLM inference server for Apple Silicon, 2-4x faster than Ollama.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
 - [Keploy](https://keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.


### PR DESCRIPTION
## What

Adds [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) to the Developer tools section, placed right after Ollama as it is a complementary local LLM inference tool.

## About Rapid-MLX

- **What it is**: OpenAI-compatible local LLM inference server optimized for Apple Silicon
- **Performance**: 2-4x faster than Ollama on Apple Silicon (M-series chips)
- **License**: Apache-2.0
- **Language**: Python
- **Key feature**: Drop-in OpenAI API replacement for local inference

It is the fastest open-source local inference server available for macOS/Apple Silicon users.