### PR TITLE
Add Chain of Thought podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,10 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [OpenAI Cookbook](https://github.com/openai/openai-cookbook) - Examples and guides for using the OpenAI API.
 - [Robert Miles AI Safety](https://www.youtube.com/@RobertMilesAI) - Youtube channel about AI safety
 
+### AI Podcasts
+
+- [Chain of Thought](https://chainofthought.show/) - A weekly podcast featuring conversations with AI leaders, engineers, and founders exploring AI development, inference infrastructure, and developer tools. Hosted by Conor Bronsdon.
+
 ## Learn AI free
 ### Machine Learning
 - [Roadmap](https://github.com/mrdbourke/machine-learning-roadmap) - A roadmap connecting many of the most important concepts in machine learning, how to learn them, and what tools to use to perform them.

--- a/README.md
+++ b/README.md
@@ -557,7 +557,11 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### AI Podcasts
 
-- [Chain of Thought](https://chainofthought.show/) - A weekly podcast featuring conversations with AI leaders, engineers, and founders exploring AI development, inference infrastructure, and developer tools. Hosted by Conor Bronsdon.
+- [Chain of Thought](https://chainofthought.show/) - Interviews with AI leaders on inference infrastructure, developer tools, and strategy.
+- [How I AI](https://www.youtube.com/@howiaipodcast) - Claire Vo talks to builders about how they actually use AI day to day.
+- [Latent Space](https://www.latent.space/podcast) - Technical AI engineering podcast focused on LLMs and developer tooling.
+- [Practical AI](https://practicalai.fm/) - AI made practical and accessible, from the Changelog network.
+- [TWIML AI](https://twimlai.com/) - Long-running show with researchers and practitioners across ML.
 
 ## Learn AI free
 ### Machine Learning


### PR DESCRIPTION
Adding an AI Podcasts subsection with five curated podcasts:

- [Chain of Thought](https://chainofthought.show/) - Inference infrastructure, developer tools, and strategy
- [How I AI](https://www.youtube.com/@howiaipodcast) - Practical AI usage from builders and operators
- [Latent Space](https://www.latent.space/podcast) - Technical AI engineering and LLMs
- [Practical AI](https://practicalai.fm/) - AI made practical and accessible
- [TWIML AI](https://twimlai.com/) - Researchers and practitioners across ML

All actively maintained shows relevant to the AI tools audience.