### PR TITLE
Add webclaw — web extraction toolkit for LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Keploy](https://keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.
 - [LangChain](https://langchain.com/) - A framework for developing applications powered by language models.
 - [Portia AI](https://www.portialabs.ai/) - Open source framework for building agents that pre-express their planned actions, share their progress and can be interrupted by a human. [#opensource](https://github.com/portiaAI/portia-sdk-python)
+- [webclaw](https://github.com/0xMassi/webclaw) - Web content extraction toolkit for LLMs. CLI + MCP server with TLS fingerprinting, 10 extraction tools, and token-optimized output. Rust, MIT licensed. [#opensource](https://github.com/0xMassi/webclaw)
 - [gpt4all](https://github.com/nomic-ai/gpt4all) - A chatbot trained on a massive collection of clean assistant data including code, stories, and dialogue.
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.
 - [LlamaIndex](https://www.llamaindex.ai/) - A data framework for building LLM applications over external data.


### PR DESCRIPTION
Adds [webclaw](https://github.com/0xMassi/webclaw) to Developer tools.

Open source web content extraction toolkit (Rust, MIT). CLI + MCP server that extracts clean markdown from any URL using TLS fingerprinting. 10 tools, 67% fewer tokens than raw HTML.

https://github.com/0xMassi/webclaw