### PR TITLE
Add A2ASearch — searchable directory for AI agents and MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Developer tools
 
+- [A2ASearch](https://a2asearch.ai) - Searchable directory of 4,800+ AI agents, MCP servers, CLI tools and agent skills. Free REST API + MCP server for Claude/Cursor. [#opensource](https://github.com/tadas-github/a2asearch)
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Developer tools
 
-- [A2ASearch](https://a2asearch.ai) - Searchable directory of 4,800+ AI agents, MCP servers, CLI tools and agent skills. Free REST API + MCP server for Claude/Cursor. [#opensource](https://github.com/tadas-github/a2asearch)
+- [A2ASearch](https://github.com/tadas-github/a2asearch) - Searchable directory of 4,800+ AI agents, MCP servers, CLI tools and agent skills. Free REST API + MCP server for Claude/Cursor. [Website](https://a2asearch.ai)
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.


### PR DESCRIPTION
Adding [A2ASearch](https://a2asearch.ai) to Developer Tools — it indexes 4,800+ AI agents, MCP servers, CLI tools and agent skills with a free REST API and an MCP server for Claude/Cursor (`npx -y a2asearch-mcp`).