### PR TITLE
Add BotVa to Chatbots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gali Chat](https://www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
 - [DeepSeek-R1](https://www.deepseek.com) - *[reviews](https://altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
 - [dmwithme](https://dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
+- [BotVa](https://github.com/cohe4ko/BotVa) - Self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination. [#opensource](https://github.com/cohe4ko/BotVa)
 
 
 ### Search engines


### PR DESCRIPTION
## Summary

- Adds [BotVa](https://github.com/cohe4ko/BotVa) to the Chatbots section
- BotVa is a self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination
- MIT licensed, open source

## Details

- Repository: https://github.com/cohe4ko/BotVa
- License: MIT
- Entry added at the bottom of the Chatbots category, following existing format with `#opensource` tag