### PR TITLE
Add Agency Orchestrator to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Agency Orchestrator](https://github.com/jnMetaCode/agency-orchestrator) - YAML-first multi-agent workflow orchestrator with 186 built-in AI roles, auto DAG parallelism, conditions/loops/resume. Zero code. Works with DeepSeek, Claude, OpenAI, Ollama. [#opensource](https://github.com/jnMetaCode/agency-orchestrator)
 
 
 ## Code


### PR DESCRIPTION
## Summary

Adding [Agency Orchestrator](https://github.com/jnMetaCode/agency-orchestrator) to the Developer tools section.

- **What**: YAML-first multi-agent workflow orchestrator with 186 built-in AI roles
- **Key features**: Auto DAG parallelism, conditional branching, iterative loops, resume from any step — zero code required
- **LLM support**: DeepSeek, Claude, OpenAI, Ollama
- **License**: Apache-2.0

## Placement

Added at the end of the Developer tools section, following the existing list format with `#opensource` tag linking to the GitHub repo.

## Checklist

- [x] Follows existing entry format
- [x] Project is open source
- [x] Link is valid