### PR TITLE
Add claude-code-power-stack to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 
 ### Developer tools
+- [Claude Code Power Stack](https://github.com/bluzername/claude-code-power-stack) - Curated toolkit bundling Ghost (persistent memory), cc-conversation-search (cross-project session search), session naming, and Manus-style file-based planning for Claude Code. One-command install with cheat sheet PDF.
 
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.


### PR DESCRIPTION
Hey, wanted to add my project here. I build this toolkit for Claude Code that bundles several useful tools together like persistent memory, conversation search across projects, and file-based planning. It installs everything with one command so people don't have to set up each tool separately. Hope it can be useful for other developers too.