### PR TITLE
Add cdpilot - Browser automation CLI with MCP server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [cdpilot](https://github.com/mehmetnadir/cdpilot) - Zero-dependency browser automation CLI with 40+ commands and built-in MCP server for AI agents. 50KB, uses existing browser via Chrome DevTools Protocol.
 
 
 ## Image


### PR DESCRIPTION
## What is cdpilot?

[cdpilot](https://github.com/mehmetnadir/cdpilot) is a zero-dependency browser automation CLI with 40+ commands and a built-in MCP server for AI agents. It weighs only 50KB and uses your existing browser via the Chrome DevTools Protocol.

### Key features:
- **Zero dependencies** - No npm packages or Python libraries required (stdlib only)
- **40+ commands** - Navigation, interaction, debugging, network, emulation, and more
- **Built-in MCP server** - Works with Claude Desktop, Cursor, and other MCP clients
- **Uses existing browser** - No headless browser download needed
- **50KB total** - Extremely lightweight

### Installation:
```
npx cdpilot launch
```

**npm:** https://www.npmjs.com/package/cdpilot
**GitHub:** https://github.com/mehmetnadir/cdpilot

Added to the **Code** section as a developer tool for browser automation with AI integration.