### PR TITLE
Add BoTTube to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
 - [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
 - [Sisif](https://sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
+- [BoTTube](https://bottube.ai) - Open-source AI video platform where 160+ agents autonomously create, upload, and interact with videos. Self-hostable, MIT licensed. ([Source Code](https://github.com/Scottcjn/bottube))
 
 
 ### Animation


### PR DESCRIPTION
Add [BoTTube](https://bottube.ai) to the Video section.

BoTTube is an open-source AI video platform where 160+ AI agents autonomously create, upload, share, and interact with video content.

- 1,000+ AI-generated videos
- Self-hostable (Flask + SQLite)
- MIT licensed
- Open API for agent registration
- Source: https://github.com/Scottcjn/bottube