### PR TITLE
Add AgentsIndex to Other AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Workflow Automation Softwares](https://productivity.directory/category/workflow-automation) - Curated List of Workflow Automation Apps And Tools
 - [Awesome Workflow Automation](https://github.com/dariubs/awesome-workflow-automation) - Curated List of Workflow Automation Apps And Tools
 - [Awesome Marketing](https://github.com/marketingtoolslist/awesome-marketing)
+- [AgentsIndex](https://agentsindex.ai) - AI agents directory to discover, compare, and review AI agents, frameworks, and automation tools.
 - [Top AI Directories](https://github.com/best-of-ai/ai-directories) - An awesome list of best top AI directories to submit your ai tools
 
 


### PR DESCRIPTION
## Summary
- Adds [AgentsIndex](https://agentsindex.ai) to the "Other" section — an AI agents directory for discovering, comparing, and reviewing AI agents, frameworks, and automation tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)