### PR TITLE
Add Nex to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
 - [Keploy](https://keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.
 - [LangChain](https://langchain.com/) - A framework for developing applications powered by language models.
+- [Nex](https://github.com/nex-crm/nex-as-a-skill) - Organizational context and memory for AI agents. Connects email, Slack, CRM, and 100+ tools into one knowledge graph with a 60-tool MCP server and persistent memory across sessions.
 - [Portia AI](https://www.portialabs.ai/) - Open source framework for building agents that pre-express their planned actions, share their progress and can be interrupted by a human. [#opensource](https://github.com/portiaAI/portia-sdk-python)
 - [gpt4all](https://github.com/nomic-ai/gpt4all) - A chatbot trained on a massive collection of clean assistant data including code, stories, and dialogue.
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.


### PR DESCRIPTION
Adds [Nex](https://github.com/nex-crm/nex-as-a-skill) to the Developer tools section.

Nex provides organizational context and memory for AI agents — connects email, Slack, CRM, and 100+ tools into one knowledge graph with a 60-tool MCP server and persistent memory across sessions. MIT licensed.