### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Hindsight](https://hindsight.vectorize.io) - State-of-the-art long-term memory for AI agents by Vectorize. Fully open-source and self-hostable, with integrations for LangChain, LlamaIndex, CrewAI, and more. [#opensource](https://github.com/vectorize-io/hindsight)
 
 
 ## Code


### PR DESCRIPTION
## Summary

- Adds [Hindsight](https://hindsight.vectorize.io) to the Developer tools section
- Hindsight is a state-of-the-art, open-source long-term memory system for AI agents by Vectorize
- Fully self-hostable (`pip install hindsight-all`) with integrations for LangChain, LlamaIndex, CrewAI, Pydantic AI, Vercel AI SDK, and many more
- GitHub: https://github.com/vectorize-io/hindsight