### PR TITLE
Add Safari MCP to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Safari MCP](https://github.com/achiya-automation/safari-mcp) - Native Safari browser automation MCP server for AI agents with 80+ tools via AppleScript and JavaScript on macOS. [#opensource](https://github.com/achiya-automation/safari-mcp)
 
 
 ## Code


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** Safari MCP
- **Description:** Native Safari browser automation MCP server for AI agents with 80+ tools via AppleScript and JavaScript on macOS.
- **Tool URL:** https://github.com/achiya-automation/safari-mcp
- **Altern.ai page link:** N/A


## 📌 Description
Added Safari MCP to the "Developer tools" section. It is an open-source MCP (Model Context Protocol) server that enables AI agents to automate Safari natively on macOS, providing 80+ tools for browser automation through AppleScript and JavaScript.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---


## 🛠 Type of Change
- [ ] 📚 Documentation / README update
- [x] ➕ Adding a new AI tool
- [ ] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix
- [ ] Other (please specify):

---


## 📷 Screenshots / Demo (if applicable)
N/A

---

## 💡 Additional Notes
Safari MCP is fully open-source and published on npm as `safari-mcp`.