### PR TITLE
Add Hashgraph Online to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Riffo](https://riffo.ai/) - An AI-powered file management tool for bulk renaming and automatic folder organization.
 - [SlidesWizard](https://slideswizard.io) - Create Presentations 10x faster. Generate PowerPoint and Google Slides presentations about any topic with AI
 - [Transgate](https://transgate.ai/) - AI Speech to Text
+- [Hashgraph Online](https://hol.org) - Trust engine for the agentic internet. Provides verifiable agent identity (Universal Agent IDs), trustless P2P communication, and a registry of 187K+ verified AI agents.
 - [RabbitHoles AI](https://www.rabbitholes.ai/) - Chat with AI on an Infinite Canvas
 - [Rember](https://www.rember.com/) - A simple yet powerful spaced repetition system designed to help you remember more.
 - [Qurate](https://qurate.appcradle.net/) - AI Quote Companion, which can help in finding relavant quotes according to the context.


### PR DESCRIPTION
## Hashgraph Online (HOL) - Trust Engine for the Agentic Internet

Adding [Hashgraph Online](https://hol.org) to the **Productivity** section.

**Why it fits:** HOL provides agent infrastructure that sits alongside tools like Taskade, BrainSoup, and MindPal in the productivity/AI agents space:

- **Universal Agent ID (UAID)**: Verifiable agent identity (HCS-14)
- **HCS-10**: Trustless P2P communication protocol for AI agents
- **Registry**: 187K+ verified agents, 33M+ daily operations
- **Open source**: [github.com/hashgraph-online](https://github.com/hashgraph-online)