### PR TITLE
Add StockKit - Free AI Stock Research Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Scenario](https://www.scenario.com/) - AI-generated gaming assets.
 - [Teleprompter](https://github.com/danielgross/teleprompter) - An on-device AI for your meetings that listens to you and makes charismatic quote suggestions.
 - [FinChat](https://finchat.io/) - Using AI, FinChat generates answers to questions about public companies and investors.
+- [StockKit](https://stockkit.net/) - Free AI-powered stock research reports delivered daily. Wall Street-grade analysis for US, China & HK stocks using Claude Opus and multi-model AI. [#opensource](https://github.com/kentmswood-ui/stockkit)
 - [Petals](https://github.com/bigscience-workshop/petals) - BitTorrent style platform for running AI models in a distributed way.
 - [Shotstack Workflows](https://shotstack.io/product/workflows/) - No-code, automation workflow tool for building Generative AI media applications.
 - [Aispect](https://aispect.io/?ref=mahseema-awesome-ai-tools) - New way to experience events.


### PR DESCRIPTION
## Add StockKit

**[StockKit](https://stockkit.net/)** — Free AI-powered stock research reports delivered daily.

### What it does
- Wall Street-grade AI analysis using Claude Opus and multi-model AI engine
- Covers US stocks, China A-shares, and Hong Kong stocks  
- 20+ technical indicators (MA, MACD, RSI, Bollinger Bands)
- Daily reports delivered to email after market close or before open
- 100% free, no account needed

### Why it belongs here
StockKit is an AI tool that uses LLMs (Claude Opus, Gemini, DeepSeek, GLM-5) to generate institutional-grade financial analysis reports. It fits in the "Other" section alongside similar AI-powered analysis tools like FinChat.

### Links
- Website: https://stockkit.net
- GitHub: https://github.com/kentmswood-ui/stockkit (MIT License, open source)