### PR TITLE
feat: add MarketCore Toolkit to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[MarketCore Toolkit](https://toolkit-directory-1090035465538.us-central1.run.app)** - Curated directory of 275+ MCP servers and AI tools for marketing, with editorial scores across SEO, content, email, social media, analytics, and CRM
 
 
 ### Phone Calls


### PR DESCRIPTION
## What

Adds **MarketCore Toolkit** to the Marketing AI Tools section — a curated directory of 275+ marketing-focused MCP servers and AI tools.

**URL:** https://toolkit-directory-1090035465538.us-central1.run.app

## Why it fits

MCP (Model Context Protocol) is the standard protocol for connecting AI assistants like Claude to external marketing tools. MarketCore Toolkit is the leading curated directory for marketing-focused MCP servers:

- **275+ tools** across SEO, content creation, email, social media, analytics, ad platforms, and CRM
- **Editorial reviews** with scores for Marketing Relevance, Output Quality, Installation, Documentation, and Maintenance
- **Comparison pages** to help marketers choose between similar tools
- Fills a gap alongside your existing [marketing.md](https://github.com/mahseema/awesome-ai-tools/blob/main/marketing.md) — that file covers individual tools; MarketCore is a discovery layer for marketers new to AI

Fits naturally in the Marketing AI Tools section alongside tools like Jasper AI and MarketMuse.