### PR TITLE
Add Kviskr to Speech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Bark](https://github.com/suno-ai/bark) - A transformer-based text-to-audio model. #opensource
 - [CustomPod.io](https://custompod.io) - Generate daily news podcasts only on the topics you care about.
 - [EKHOS AI](https://ekhos.ai) - An AI speech-to-text software with powerful proofreading features. Transcribe most audio or video files with real-time recording and transcription.
+- [Kviskr](https://kviskr.no) - A macOS menu bar app for speech-to-text using whisper.cpp with CoreML for fast, local transcription. Specialized for Norwegian with NB-Whisper. Features speaker diarization and AI post-processing.
   
 ### Music
 


### PR DESCRIPTION
## Summary
- Add [Kviskr](https://kviskr.no) to the Speech section
- Kviskr is a macOS menu bar app for speech-to-text using whisper.cpp with CoreML for fast, local transcription
- Specialized for Norwegian with NB-Whisper from NbAiLab
- Features speaker diarization and AI post-processing
- Free, macOS 14+, Apple Silicon