### PR TITLE
Add Pisama to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ChatWithCloud](https://chatwithcloud.ai/) - CLI allowing you to interact with AWS Cloud using human language inside your Terminal.
 - [SinglebaseCloud](https://singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.
 - [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
+- [Pisama](https://pisama.ai) - Open-source agent forensics platform. Detect 20 types of failures in multi-agent AI systems — loops, state corruption, hallucination, persona drift, and more. Tiered heuristic detection at $0/trace.
 - [Wordware](https://www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
 - [CodeRabbit](https://coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  


### PR DESCRIPTION
Adds [Pisama](https://pisama.ai) to the Developer tools section — an open-source agent forensics platform for detecting failures in multi-agent AI systems.

- 20 failure type detectors (loops, state corruption, hallucination, persona drift, and more)
- Tiered heuristic detection at $0/trace
- Python SDK, CLI, and MCP server
- Works with LangGraph, CrewAI, AutoGen, n8n, Dify
- MIT licensed

[GitHub](https://github.com/tn-pisama/pisama) | [Docs](https://docs.pisama.ai) | [PyPI](https://pypi.org/project/pisama/)