### PR TITLE
Add videobackgroundremover to AI video tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [D-ID](https://www.d-id.com/) - Create and interact with talking avatars at the touch of a button.
 - [ShortVideoGen](https://shortgen.video/) - Create short videos with audio using text prompts.
 - [Clipwing](https://clipwing.pro/) - A tool for cutting long videos into dozens of short clips.
+- [videobackgroundremover](https://videobackgroundremover.org/) - AI video background remover for clean cutouts and background replacement without a green screen.
 - [Recast Studio](https://recast.studio) - AI powered podcast marketing assistant.
 - [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
 - [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.


### PR DESCRIPTION
Adds videobackgroundremover.org, an AI video background removal tool for creators who need clean cutouts or quick background replacement without a green screen.\n\nPlaced in the Video section.