### PR TITLE
Add Git AutoReview to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
 - [Wordware](https://www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
 - [CodeRabbit](https://coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
+- [Git AutoReview](https://gitautoreview.com) - AI code review VS Code extension that runs three models (Claude, GPT, Gemini) against PRs to catch bugs and security issues. Works with GitHub, GitLab, and Bitbucket.
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.


### PR DESCRIPTION
Added **Git AutoReview** to the Developer tools section, next to CodeRabbit and other code review tools.

## How it's different from CodeRabbit (which is already on this list)

CodeRabbit auto-publishes every AI comment directly to your pull request. If the model gets something wrong — and they do, roughly 30-40% of the time depending on the codebase — that bad suggestion is already live for your whole team to see.

Git AutoReview flips that: AI suggestions appear as drafts inside VS Code. You read each one, approve what's useful, toss what isn't. Nothing gets posted until you say so. That's the core difference — the human stays in the loop.

Beyond that:
- **Three AI models** (Claude, Gemini, GPT) instead of one. Run two in parallel if you want a second opinion
- **BYOK** — use your own API key. If you already pay for Claude Code or GitHub Copilot, the extension costs nothing extra
- **Pre-commit review** — catch bugs before they enter git history, not just after a PR exists
- **GitHub + GitLab + Bitbucket** — including GitLab Self-Managed and Bitbucket Server/DC, which most tools skip

Free tier does 10 reviews/day with no time limit. Paid plans start at $9.99/month (flat, not per-user).

- **Website:** https://gitautoreview.com
- **VS Code Marketplace:** https://marketplace.visualstudio.com/items?itemName=vitalii4reva.git-autoreview