### PR TITLE
Add Ptah - multi-provider AI coding orchestra

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.
 - [Calmo](https://getcalmo.com/) - Debug Production x10 Faster with AI.
 - [Cleanlab](https://help.cleanlab.ai/tlm/) - Detect and remediate hallucinations in any LLM application.
+- [Ptah](https://github.com/Hive-Academy/ptah-extension) - Multi-provider AI coding orchestra for VS Code and desktop. Connects to OpenRouter (200+ models), Kimi, GLM, Copilot, Gemini, and Codex from one interface with CLI agent orchestration, MCP server, and plugin ecosystem. [#opensource](https://github.com/Hive-Academy/ptah-extension)
 - [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows.
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** Ptah - The Coding Orchestra
- - **Description:** Multi-provider AI coding orchestra for VS Code and desktop that connects to OpenRouter (200+ models), Kimi, GLM, Copilot, Gemini, and Codex from one interface with CLI agent orchestration, MCP server, and plugin ecosystem.
- - **Tool URL:** https://github.com/Hive-Academy/ptah-extension
- - **Altern.ai page link:** N/A
## Description

Added [Ptah](https://github.com/Hive-Academy/ptah-extension) to the **Developer tools** section.

Ptah is an open-source AI coding tool available as a VS Code extension and standalone Electron desktop app. It connects to multiple AI providers from one unified interface:

- **Multi-provider support**: OpenRouter (200+ models), Moonshot/Kimi (K2, K2.5), Z.AI/GLM (including free models), GitHub Copilot, Gemini CLI, OpenAI Codex, and direct Anthropic API
- - **CLI agent orchestration**: Spawn background AI agents from different providers and manage them via 6 MCP lifecycle tools (spawn, status, read, steer, stop, list)
- - **Built-in MCP server**: 14 API namespaces for workspace intelligence — semantic file search, tree-sitter AST analysis, diagnostics, dependency graphs, git operations
- - **Plugin ecosystem**: 4 plugin packs with 19+ skills (orchestration workflows, code review, Angular, NestJS, React patterns)
- - **Workspace intelligence**: Setup wizard scans your codebase and tailors AI interactions to your specific stack
Open source under FSL-1.1-MIT license.

- VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=ptah-extensions.ptah-coding-orchestra
- - Website: https://ptah.live
---

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] - [x] **Only one tool is modified in this PR**
- [ ] - [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [ ] - [x] The tool link is **valid** and accessible
- [ ] - [x] The tool is **not already listed**