### PR TITLE
Add Typer - free local AI chat for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gali Chat](https://www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
 - [DeepSeek-R1](https://www.deepseek.com) - *[reviews](https://altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
 - [dmwithme](https://dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
+- [Typer](https://typer.space) - Free local AI chat for macOS. Runs entirely on-device — no account, no cloud, no ads. Works offline. Apple Silicon required.
 
 
 ### Search engines


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** Typer
- **Description:** Free local AI chat for macOS (Apple Silicon) — runs entirely on-device, no account, no cloud, works offline with on-device web search.
- **Tool URL:** https://typer.space
- **Altern.ai page link:** N/A

## 📌 Description
Adds Typer to the **Chatbots** section as a privacy-first, offline-capable alternative to cloud-based AI chatbots. Typer runs AI models entirely on-device on Apple Silicon Macs — no account required, no data sent to any server, no ads, works fully offline. It also supports on-device web search without sending queries to external servers.

Added at the end of the Chatbots section.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool

---

## 📷 Screenshots / Demo (if applicable)
Website: https://typer.space
App Store: https://apps.apple.com/app/typer-ai/id6751274483

---

## 💡 Additional Notes
Typer is free, closed-source (proprietary freeware), requires Apple Silicon (M-series Mac), and is distributed via the Mac App Store. The submitter is affiliated with the product.