### PR TITLE
Add clideck to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
 
 
+- [clideck](https://github.com/rustykuntz/clideck) - WhatsApp-like dashboard for managing multiple AI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) in one browser window. Live status, session resume, autopilot routing between agents, and mobile remote.
+
 ## Image
 
 *For a more complete list of AI Image tools visit: [Best Image AI Tools](https://github.com/mahseema/awesome-ai-tools/blob/main/IMAGE.md) or [Awesome AI Image](https://github.com/xaramore/awesome-ai-image)*


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** clideck
- **Description:** WhatsApp-like dashboard for managing multiple AI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) in one browser window. Live status, session resume, autopilot routing between agents, and mobile remote.
- **Tool URL:** https://github.com/rustykuntz/clideck
- **Altern.ai page link:** N/A

## 📌 Description
Added clideck to the Code section. It is a local browser dashboard for managing multiple AI coding agents in one window — not a code generation tool itself, but a management layer for agents that are.

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool