### PR TITLE
Add prompt-defense-audit to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Cleanlab](https://help.cleanlab.ai/tlm/) - Detect and remediate hallucinations in any LLM application.
 - [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows.
+- [prompt-defense-audit](https://github.com/ppcvote/prompt-defense-audit) - Deterministic LLM system prompt defense scanner. Checks 12 attack vectors using pure regex, <5ms, zero deps. Also on npm.
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
 - [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
 - [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.


### PR DESCRIPTION
Adds [prompt-defense-audit](https://github.com/ppcvote/prompt-defense-audit) — a deterministic LLM system prompt defense scanner.

- 12 attack vectors (OWASP LLM Top 10 mapped)
- Pure regex, <5ms, zero dependencies
- Available on npm: `npx prompt-defense-audit "Your prompt"`
- MIT licensed