### PR TITLE
Add Global Chat — AI agent discovery across MCP, A2A, agents.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Global Chat](https://global-chat.io) - Cross-protocol AI agent discovery platform. Search and register agents across MCP, A2A, and agents.txt protocols with a searchable directory of 100K+ agents. [#opensource](https://github.com/pumanitro/global-chat)
 
 
 ## Code


### PR DESCRIPTION
Hi! I'd like to add [Global Chat](https://global-chat.io) to the Developer tools section.

**What it does:** Global Chat is an open-source, cross-protocol AI agent discovery platform. It aggregates agents from MCP, A2A, agents.txt, ACDP, and 12 other registries into a single searchable directory of 100K+ agents. It also ships a free agents.txt validator/linter and an MCP server (`@global-chat/mcp-server` on npm) for programmatic access.

**Why it belongs here:** The AI agent ecosystem is fragmented across dozens of incompatible registries. Global Chat solves the discovery problem by providing one search interface across all of them — useful for any developer building with or connecting to AI agents.

- Website: https://global-chat.io
- GitHub: https://github.com/pumanitro/global-chat
- npm: [@global-chat/mcp-server](https://www.npmjs.com/package/@global-chat/mcp-server)

Thanks for maintaining this list!