### PR TITLE
Add Onepilot to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [Onepilot](https://onepilotapp.com) - An iOS app for SSHing into remote servers to run Claude Code, Codex, and other CLI coding tools — plus one-click AI agent deployment via OpenClaw.
 
 
 ## Image


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com) to the Code section.

Onepilot is an iOS app for SSHing into remote servers to run Claude Code, Codex, and other CLI coding tools — plus one-click AI agent deployment via OpenClaw. It fills a gap in the list — there's no mobile-first tool for running coding agents on remote machines.

Available on the [App Store](https://apps.apple.com/app/id6743597406).