### PR TITLE
Add BrainDB - AI Memory & Multi-Agent Orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ## Other
 
+- [BrainDB](https://github.com/beckfexx/BrainDB) - Local-first AI memory and multi-agent orchestrator. 110 REST endpoints, 51 MCP tools, hybrid search (SQLite FTS5 + semantic), self-learning, knowledge graph. TypeScript, Bun, AGPL-3.0.
 - [Taranify](https://www.taranify.com) - Using AI, Taranify finds you Spotify playlists, Netflix shows, Books & Foods you'd enjoy when you don't exactly know what you want. 
 - [Diagram](https://diagram.com/) - Magical new ways to design products.
 - [PromptBase](https://promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.


### PR DESCRIPTION
## Add BrainDB

[BrainDB](https://github.com/beckfexx/BrainDB) — Local-first AI memory and multi-agent orchestrator with 110 REST endpoints, 51 MCP tools, hybrid search (SQLite FTS5 + semantic), self-learning, and knowledge graph. TypeScript, Bun, AGPL-3.0.

Added to the Other section.