### PR TITLE
Add Agent Brain to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.
 - [LlamaIndex](https://www.llamaindex.ai/) - A data framework for building LLM applications over external data.
 - [Langfuse](https://langfuse.com/) - Open-source LLM engineering platform that helps teams collaboratively debug, analyze, and iterate on their LLM applications. [#opensource](https://github.com/langfuse/langfuse)
+- [Agent Brain](https://agentbrain.ch) - 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Self-hostable. [#opensource](https://github.com/kaderosio/agent-brain)
 - [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine-tune LLM, CV, and tabular models.
 - [Prediction Guard](https://www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.
 - [Portkey](https://portkey.ai/) - Full-stack LLMOps platform to monitor, manage, and improve LLM-based apps.


### PR DESCRIPTION
Adds [Agent Brain](https://github.com/kaderosio/agent-brain) to the Developer tools section.

Agent Brain is an open-source 7-layer cognitive memory system for AI agents. Self-hostable via Docker, built with FastAPI and PostgreSQL/pgvector.