### PR TITLE
Add Alpha Skills — AI skills for quantitative factor research

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Alpha Skills](https://github.com/VernonOY/alpha-skills) - Open-source AI skills that turn any coding assistant into a quant factor research workstation. Automated factor mining, multi-level evaluation, lifecycle monitoring.
 
 
 ## Code


### PR DESCRIPTION
Adding [Alpha Skills](https://github.com/VernonOY/alpha-skills) — 7 open-source AI skills for quantitative factor research.

Works with any AI coding assistant (Cursor, Windsurf, Claude Code, ChatGPT). Skills include automated factor mining, multi-level evaluation (IC/ICIR/quintile/robustness), factor lifecycle monitoring, and portfolio backtesting. Supports A-share, HK, and US equities. Self-contained Markdown files, zero dependencies.