### PR TITLE
Add LIIVO - deploy apps your AI built

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [LIIVO](https://www.liivo.ai) - Deploy apps your AI built. Connect Claude or ChatGPT, describe what you want, and LIIVO runs it on open-source infrastructure you can take anywhere. Flat EUR 15/month, zero vendor lock-in.
 
 
 ## Image


### PR DESCRIPTION
## What is LIIVO?

[LIIVO](https://www.liivo.ai) lets non-technical users deploy apps their AI built. Connect Claude or ChatGPT, describe what you want, and LIIVO runs it on open-source infrastructure you can take anywhere.

## Why it belongs in the Code section

Most AI coding tools help you generate code. LIIVO solves the next step: getting that code running in production. It is aimed at people using AI to build apps but who do not want to manage servers, configs, or cloud accounts themselves. Flat EUR 15/month, zero vendor lock-in.

## Entry added

```
- [LIIVO](https://www.liivo.ai) - Deploy apps your AI built. Connect Claude or ChatGPT, describe what you want, and LIIVO runs it on open-source infrastructure you can take anywhere. Flat EUR 15/month, zero vendor lock-in.
```

Added at the end of the `## Code` section.