### PR TITLE
Add RemembrallMCP to Developer tools - MCP memory layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [RemembrallMCP](https://github.com/cdnsteve/remembrallmcp) - Persistent memory and code graph server for AI agents. MCP protocol, Postgres/pgvector backend, hybrid semantic + full-text search, incremental code indexing for 7 languages with blast-radius impact analysis. Self-hosted, no external API needed.
 
 
 ## Code


### PR DESCRIPTION
## Summary

Adds RemembrallMCP to the Developer tools subsection under "Code with AI".

**URL:** https://github.com/cdnsteve/remembrallmcp

RemembrallMCP is an open-source MCP server that gives AI agents persistent memory across sessions. It stores decisions and context using Postgres/pgvector, supports hybrid semantic + full-text search, and builds a code dependency graph for 7 programming languages. Designed for developers using Claude Code, Cursor, or other MCP-compatible AI tools.

- Self-hosted (Docker + Postgres)
- Written in Rust, in-process ONNX embeddings
- MCP protocol compatible

## Checklist

- [x] Entry follows the existing format (dash, bracketed link, description)
- [x] Entry is accurate and not promotional
- [x] Fits the Developer tools subsection