### PR TITLE
Add resume-cli - TUI for AI coding session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [resume-cli](https://github.com/inevolin/resume-cli) - TUI to resume AI coding sessions across Claude Code, GitHub Copilot CLI, and Codex from a single interactive picker; supports cross-tool context loading.
 
 
 ## Code


### PR DESCRIPTION
## Summary

Adds `resume-cli` to the **Developer tools** section.

- **npm:** `ai-resume-cli`
- **GitHub:** https://github.com/inevolin/resume-cli
- TUI to resume AI coding sessions across Claude Code, GitHub Copilot CLI, and Codex from a single interactive picker; supports cross-tool context loading.

## Why this fits

`resume-cli` is a developer-facing CLI/TUI tool that enhances AI coding workflows — a natural fit for the Developer tools subsection alongside other terminal and workflow tools.