### PR TITLE
Add PromptVault to ChatGPT extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Chatbot UI](https://www.chatbotui.com/) - An open source ChatGPT UI. [Source code](https://github.com/mckaywrigley/chatbot-ui).
 - [Forefront](https://www.forefront.ai/) - A Better ChatGPT Experience.
 - [AI Character for GPT](https://chromewebstore.google.com/detail/ai-character-for-gpt/daoeioifimkjegafelcaljboknjkkohh) - One click to curate AI chatbot, including ChatGPT, Google Bard to improve AI responses.
+- [PromptVault](https://chromewebstore.google.com/detail/promptvault-ai-prompt-m/kpmbjcjomgnooagjloikpcgaejncadng) - AI prompt manager that saves and injects expert prompts into ChatGPT, Claude, Gemini, Mistral, DeepSeek, Grok and 5+ more. Free, with dynamic variables and shortcut palette.
 
 ### Productivity
 


### PR DESCRIPTION
Add PromptVault to the ChatGPT extensions section.

**PromptVault** is a free Chrome extension that saves your best AI prompts and injects them into 10+ AI platforms (ChatGPT, Claude, Gemini, Mistral, DeepSeek, Grok, Copilot, Poe, HuggingChat, Perplexity) with a single click.

Key features:
- Local vault with cross-device sync
- Dynamic variables ({{topic}}, {{tone}}, {{length}})
- 12 built-in expert prompts (SCAMPER, PAS, STAR, role definitions)
- Floating palette with Ctrl+Shift+P shortcut
- 100% free, core will stay free forever

Chrome Web Store: https://chromewebstore.google.com/detail/promptvault-ai-prompt-m/kpmbjcjomgnooagjloikpcgaejncadng

Thanks for maintaining this list.