### PR TITLE
Add Dexto - Open agent harness with coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [Dexto](https://github.com/truffle-ai/dexto) - An open agent harness that ships with a production-ready coding agent for CLI and web, featuring YAML-based configuration, 50+ LLM support, MCP tools, and persistent memory.
 
 
 ## Image


### PR DESCRIPTION
## Add Dexto

Adding [Dexto](https://github.com/truffle-ai/dexto) to the Code section.

**Description:** An open agent harness that ships with a production-ready coding agent for CLI and web, featuring YAML-based configuration, 50+ LLM support, MCP tools, and persistent memory.

- **Type:** CLI, Web
- **License:** Elastic 2.0
- **Pricing:** Free