### PR TITLE
Add SwarmVault to Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first knowledge compiler that turns files, URLs, PDFs, and code into a markdown wiki with a graph and search index, usable from the CLI, MCP, or Obsidian.
 
 
 ## Image


### PR DESCRIPTION
Adds a single-line entry for SwarmVault to the Code section.

SwarmVault is a local-first knowledge compiler. Its CLI turns files, URLs, PDFs, and code into a markdown wiki with a graph and search index. The vault can be queried from the command line, through the bundled MCP server, or from inside Obsidian via the community plugin.

- Repo: https://github.com/swarmclawai/swarmvault
- License: MIT
- Active: daily commits, v0.7.30 shipped this week
- Provider pluggable: Anthropic, OpenAI, Ollama, Gemini, and others, plus a heuristic offline mode

Appended at the bottom of the Code section. Diff is a single insertion.
