### PR TITLE
Add CC Telegram Bridge to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [CC Telegram Bridge](https://github.com/cloveric/cc-telegram-bridge) - Run real Claude Code & Codex CLI natively on Telegram — multi-bot, sessions, memory, Agent Bus, voice input, budget caps. Not an API wrapper. [#opensource](https://github.com/cloveric/cc-telegram-bridge)
 
 
 ## Code


### PR DESCRIPTION
## Summary

- Adds [CC Telegram Bridge](https://github.com/cloveric/cc-telegram-bridge) to the **Developer tools** section.
- CC Telegram Bridge lets you run real Claude Code and Codex CLI natively on Telegram with multi-bot support, sessions, memory, Agent Bus, voice input, and budget caps. It is fully open source and not an API wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)