### PR TITLE
Add Helium - AI-powered news intelligence and financial analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Scenario](https://www.scenario.com/) - AI-generated gaming assets.
 - [Teleprompter](https://github.com/danielgross/teleprompter) - An on-device AI for your meetings that listens to you and makes charismatic quote suggestions.
 - [FinChat](https://finchat.io/) - Using AI, FinChat generates answers to questions about public companies and investors.
+- [Helium](https://heliumtrades.com) - AI-powered news intelligence with bias scoring across 5,000+ sources and 15+ dimensions, balanced news synthesis, live stock/ETF/crypto data with AI analysis, ML options pricing, and meme search. Available as [MCP server](https://github.com/connerlambden/helium-mcp) for AI assistants.
 - [Petals](https://github.com/bigscience-workshop/petals) - BitTorrent style platform for running AI models in a distributed way.
 - [Shotstack Workflows](https://shotstack.io/product/workflows/) - No-code, automation workflow tool for building Generative AI media applications.
 - [Aispect](https://aispect.io/?ref=mahseema-awesome-ai-tools) - New way to experience events.


### PR DESCRIPTION
## Summary

- Adds [Helium](https://heliumtrades.com) to the Other section alongside other finance/research AI tools
- Helium is an AI-powered news intelligence platform with bias scoring across 5,000+ sources and 15+ dimensions, balanced news synthesis aggregating multiple perspectives, live stock/ETF/crypto data with AI bull/bear analysis, ML options pricing, and meme search
- Also available as an [MCP server](https://github.com/connerlambden/helium-mcp) for AI assistants (50 free queries, no signup required)

## Details

- **Website:** https://heliumtrades.com
- **MCP Page:** https://heliumtrades.com/mcp-page/
- **GitHub:** https://github.com/connerlambden/helium-mcp


Made with [Cursor](https://cursor.com)