### PR TITLE
Add Burn — AI reading triage to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [Burn](https://burn451.cloud) - AI-powered reading triage with a 24h burn timer. Every saved article forces a decision: read it, absorb it, vault it, or let it burn. MCP server with 26 tools lets Claude/Cursor/Windsurf work with your reading. Read less, absorb more.
 
 
 ### Meeting assistants


### PR DESCRIPTION
Adding [Burn](https://burn451.cloud) to the **Productivity** section.

Burn is an information processing system with a 24h burn timer. Every saved article forces a decision: read it, skim it, let AI process it, vault it, or let it burn. The MCP server (26 tools) lets Claude/Cursor/Windsurf work with your reading.

- Homepage: https://burn451.cloud
- GitHub: https://github.com/Fisher521/killmybookmark
- Platforms: iOS, web, Chrome extension, MCP server
- License: MIT