### PR TITLE
Add Not Human Search to Search Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [MemFree](https://github.com/memfreeme/memfree) - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs
 - [Refinder AI](https://refinder.ai/) - AI-powered universal search and assistant for work
 - [Agentset.ai](https://agentset.ai/) - Open-source local Semantic Search + RAG for your data
+- [Not Human Search](https://nothumansearch.ai/) - Search engine built for AI agents with MCP server and REST API. Indexes 8,600+ sites scored 0–100 on agentic readiness signals.
 
 ### Local search engines
 


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai/) to the **Search engines** section.

Not Human Search is a search engine built for AI agents (not humans). It indexes 8,600+ sites and scores each 0–100 on agentic readiness signals. Includes an MCP server and REST API for programmatic access.

Entry follows the existing `- [Name](url) - Description` format used throughout the list.