### PR TITLE
Add Burn 451 — AI reading tool with curated thought-leader vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Productivity
 
+- [Burn 451](https://www.burn451.cloud) - AI-powered reading tool. Curated vaults of essays/podcasts from Karpathy, Simon Willison, PG, Naval + hub concept pages on agentic engineering and vibe coding. AI summaries included.
 - [Mem](https://mem.ai/) - Mem is the world's first AI-powered workspace that's personalized to you. Amplify your creativity, automate the mundane, and stay organized automatically.
 - [Taskade](https://www.taskade.com/) -  Build, train, and deploy autonomous AI agents for task management, team collaboration, and workflow automation—all within a unified workspace.
 - [Notion AI](https://www.notion.so/product/ai) - Write better, more efficient notes and docs.


### PR DESCRIPTION
Adding [Burn 451](https://www.burn451.cloud) to the Productivity section.

Burn is an AI-powered reading tool. Curated editorial vaults of essays, talks, and podcast picks from high-signal thinkers:
- [Karpathy](https://www.burn451.cloud/vault/karpathy) — 37 pieces
- [Simon Willison](https://www.burn451.cloud/vault/simon-willison) — 19
- [Paul Graham](https://www.burn451.cloud/vault/paul-graham) — 30
- [Naval Ravikant](https://www.burn451.cloud/vault/naval-ravikant) — 22

Hub concept pages:
- [Agentic Engineering](https://www.burn451.cloud/concepts/agentic-engineering)
- [Vibe Coding](https://www.burn451.cloud/concepts/vibe-coding)

AI summaries on every piece. Open source: https://github.com/Fisher521/killmybookmark