### PR TITLE
Add ShopSavvy

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI for Google Slides](https://www.aiforgoogleslides.com/) - AI presentation maker for Google Slides
 - [FARSITE](https://far.site/) - AI-powered Compliance Software for U.S. Government Contractors
 - [GOSH](https://gosh.app) - Free AI Price Tracker - Track any price of any product at any store using AI
+- [ShopSavvy](https://shopsavvy.com/desktop) - Desktop shopping assistant that autonomously finds deals, monitors prices, and can auto-buy products at target prices across thousands of retailers.
 - [BrainSoup](https://www.nurgo-software.com/products/brainsoup) Multi-agent & multi-LLM native client where AIs can remember, react to events, use tools, leverage local and external resources, and work together autonomously.
 - [MindPal](https://mindpal.space/) - Build your AI Second Brain with a team of AI agents and multi-agent workflow
 - [fabric](https://github.com/danielmiessler/fabric/) - Apply AI to everyday challenges in the comfort of your terminal. Help’s to get better results with tried and tested library of prompt pattern’s.


### PR DESCRIPTION
Adding ShopSavvy Desktop to the Productivity section. ShopSavvy is a desktop shopping assistant that autonomously finds deals, monitors prices, and can auto-buy products at target prices across thousands of retailers.

- Website: https://shopsavvy.com/desktop
- Available on Mac, Windows, and Linux