### PR TITLE
Add DishRoll to Other AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 - [Taranify](https://www.taranify.com) - Using AI, Taranify finds you Spotify playlists, Netflix shows, Books & Foods you'd enjoy when you don't exactly know what you want. 
 - [Diagram](https://diagram.com/) - Magical new ways to design products.
+- [DishRoll](https://dishroll.netlify.app/) - AI-powered weekly meal planner that generates personalised 7-day menus based on cuisine preferences, dietary needs, and budget, with smart shopping list export to Alexa.
 - [PromptBase](https://promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.
 - [This Image Does Not Exist](https://thisimagedoesnotexist.com/) - Test your ability to tell if an image is human or computer generated.
 - [Have I Been Trained?](https://haveibeentrained.com/) - Check if your image has been used to train popular AI art models.


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** DishRoll
- - **Description:** AI-powered weekly meal planner that generates personalised 7-day menus based on cuisine preferences, dietary needs, and budget, with smart shopping list export to Alexa.
- - **Tool URL:** https://dishroll.netlify.app/
- - **Altern.ai page link:** N/A
## Description
Added DishRoll to the "Other AI Tools" section. DishRoll is an AI-powered weekly meal planner using Claude Sonnet that generates personalised 7-day menus based on cuisine preferences (15 cuisines), dietary needs (10 options), adventure level, and grocery budget. Includes smart, deduplicated shopping list with Alexa export. MIT licensed, built with React 18 + Vite + Netlify Functions.

---

## Checklist
- [x] I have read the Contribution Guidelines
- [ ] - [x] Only one tool is modified in this PR
- [ ] - [x] All required fields (name, description, URL) are provided
- [ ] - [x] The tool link is valid and accessible
- [ ] - [x] The tool is placed in the correct category