### PR TITLE
Add Not Human Search to Search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [MemFree](https://github.com/memfreeme/memfree) - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs
 - [Refinder AI](https://refinder.ai/) - AI-powered universal search and assistant for work
 - [Agentset.ai](https://agentset.ai/) - Open-source local Semantic Search + RAG for your data
+- [Not Human Search](https://nothumansearch.ai/) - Search engine for AI agents that indexes 8,600+ tools and APIs ranked by agentic readiness. MCP server for agent-native discovery.
 
 ### Local search engines
 


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) to the Search engines section. It's an AI-native search engine that indexes 8,600+ tools and APIs ranked by agentic readiness, with an MCP server for agent-native discovery.