### PR TITLE
Add AIToolIndex to Editor's Choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 - [AI For Developers](https://aifordevelopers.org) - Just a curated list of AI agents, SDKs, coding copilots, and dev-first tools that save you hours — not waste them.
 - [There's an AI](https://theresanai.com) - List of best AI Tools
+- [AIToolIndex](https://aitoolindex.io) - Free AI tool directory with side-by-side comparisons, pricing calculators, and 72+ hand-reviewed tools across 25 categories.
 - [Notion AI](https://affiliate.notion.so/9po6cx7rvdr6-4y5a7) - Just ask Q&A, and find the info you need in seconds. Get help writing and brainstorming in Notion, not in a separate browser tab.
 - [Murf AI](https://get.murf.ai/v8i9to5ad4oq) - Create voiceover with the most lifelike AI voices.
 - [SaneBox](https://try.sanebox.com/yzkpe5s68xk2) - an email management software as a service that integrates with IMAP and Exchange Web Services email accounts.


### PR DESCRIPTION
## Summary

Adds [AIToolIndex](https://aitoolindex.io) to the **Editor's Choice** section, as a peer to the existing "There's an AI" entry (both are AI tool directories).

## Why this belongs here

- Free, hand-curated directory with **72+ reviewed AI tools** across **25 categories**
- Includes **side-by-side comparison pages** (e.g., ChatGPT vs. Perplexity, Zapier AI vs. Make) that aren't present in most other AI tool lists
- Includes **free interactive pricing calculators** (AI ROI, token cost, API pricing estimator)
- No signup required, no paywall

## Entry

```markdown
- [AIToolIndex](https://aitoolindex.io) - Free AI tool directory with side-by-side comparisons, pricing calculators, and 72+ hand-reviewed tools across 25 categories.
```

Placed right after the existing "There's an AI" entry to keep directory-type resources grouped.

Thanks for maintaining this list!
