### PR TITLE
Add AI Dev Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ezJobs](https://www.getezjobs.com/) - Automated job search and applications
 - [Compass](https://www.getwhys.io/compass) - AI driven answers to SaaS research questions
 - [Adon AI](https://adon-web.awakast.com/en/recruiter/) - CV screening automation and blind CV generator, AI backed ATS
+- [AI Dev Jobs](https://aidevboard.com) - AI and machine learning developer job board with REST API and MCP server. 5,000+ positions from 265+ companies with salary data.
 - [Persuva](https://persuva.ai) - Persuva is the AI-driven platform to create persuasive, high-converting ad copy at scale.
 - [Interview Solver](https://interviewsolver.com) - Ace your live coding interviews with our AI Copilot
 - [Socialsonic](https://socialsonic.com) - AI LinkedIn Coach: Personalized content, trends & scheduling.


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Other section.

AI Dev Jobs is an AI and machine learning developer job board with a REST API and MCP server. It indexes 5,000+ positions from 265+ companies with salary data.