### PR TITLE
Add OpenAccountants to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Rember](https://www.rember.com/) - A simple yet powerful spaced repetition system designed to help you remember more.
 - [Qurate](https://qurate.appcradle.net/) - AI Quote Companion, which can help in finding relavant quotes according to the context.
 - [FirmOS](https://www.firmos.ai/) - AI-Powered Automation for Accounting Firms
+- [OpenAccountants](https://github.com/openaccountants/openaccountants) - Open-source tax classification skills across 134 countries (VAT/GST, income tax, social contributions) with AI-powered bank statement categorization.
 - [Whisper API](https://whisper-api.com) - Whisper API is a Transcription API Powered By OpenAI Whisper model. Get 5 free transcriptions daily (no duration limits) with robust control over the model's parameters like size, temperature, beam size and more.
 - [Smmry](https://smmry.com/) - Summarize Long Content Into Clear Insights
 - [Nudge AI](https://getnudgeai.com/) - Ambient AI Scribe for Healthcare


### PR DESCRIPTION
## Summary

- Adds [OpenAccountants](https://github.com/openaccountants/openaccountants) to the **Productivity** section (next to FirmOS, another accounting tool)
- Open-source tax classification skills across 134 countries (VAT/GST, income tax, social contributions) with AI-powered bank statement categorization
- Free and open-source alternative for freelancers and small businesses preparing tax working papers

Made with [Cursor](https://cursor.com)