### PR TITLE
Add MeterCall to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [MeterCall](https://metercall.ai) - Universal API gateway over 10M+ APIs with an AI router across 25+ models. Type a sentence in plain English, get a working app. 727+ ready-made modules to fork and customize. Free tier with usage-based pricing.
 
 
 ## Image


### PR DESCRIPTION
Adding MeterCall — universal API gateway with AI router across 25+ models (Claude, GPT, Gemini, Llama, Groq, etc). Lets you type a sentence in plain English and get a working app generated. 727+ ready-made modules to fork. Free tier, usage-based pricing.

Fits the Code section as it's an AI-powered code/app generation tool similar to Capacity, FlexApp, and others already on this list. Thanks for maintaining this list.

— https://metercall.ai