### PR TITLE
Add AgentsMesh to Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [AgentsMesh](https://agentsmesh.ai) - Self-hostable AI Agent Workforce Platform that orchestrates multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode) across remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation, channels-based multi-agent collaboration, built-in Kanban, and per-pod MCP server.
 
 
 ## Image


### PR DESCRIPTION
Adding [AgentsMesh](https://agentsmesh.ai) to **Code** section.

AgentsMesh is a self-hostable AI Agent Workforce Platform that orchestrates multiple AI coding agents (not a single tool, but an orchestration layer):
- **AgentPods** — remote AI workstations with PTY sandbox + git worktree isolation
- **Multi-agent collaboration** via channels and pod bindings
- **Built-in Kanban** with ticket-pod binding and MR/PR integration
- **Per-pod MCP server** — Claude Code / Cursor integration
- **Self-hosted** — code stays on your infra
- Multi-Git (GitHub / GitLab / Gitee), multi-tenant, SSO/RBAC, BYOK
- Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode, custom agents

1.5k+ stars, v0.28.0 (2026-04-15), BSL-1.1 (→ GPL-2.0-or-later on 2030-02-28).