### PR TITLE
Add QuickSilver Pro (DeepSeek V3, R1, Qwen API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
+- [QuickSilver Pro](https://quicksilverpro.io/) - OpenAI-compatible inference API for DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B at 20% below competing resellers. Drop-in replacement for the OpenAI SDK — change only the base URL.
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.


### PR DESCRIPTION
Adds [QuickSilver Pro](https://quicksilverpro.io) to **📝 AI Text → Developer tools**.

QuickSilver Pro is an OpenAI-compatible inference API for three open-source LLMs: DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B. Pricing is 20% below OpenRouter, Together AI, and Fireworks AI on the same models. Placed adjacent to the existing AI/ML API entry since both are multi-model OpenAI-compatible API providers.

**Disclosure**: I help operate QuickSilver Pro. Happy to revise description or category if better placement suggested.