### PR TITLE
Add ShipPage to Text > Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
 
 
+- [ShipPage](https://shippage.ai) - Zero-config HTML publishing service for AI agents. One HTTP POST turns any HTML or Markdown into a public URL. Auto-registers on first call — no account, no API keys to configure. Install as OpenClaw skill or MCP server. [#opensource](https://github.com/jieshu666/ShipPage-Skill)
 ## Code
 
 - [GitHub Copilot](https://github.com/features/copilot) - GitHub Copilot uses the OpenAI Codex to suggest code and entire functions in real-time, right from your editor.


### PR DESCRIPTION
Adds [ShipPage](https://shippage.ai) to **Text → Developer tools**.

Zero-config HTML publishing for AI agents. One HTTP POST turns any HTML or Markdown into a public URL at shippage.ai/p/{slug}. Built on Cloudflare Workers. MIT-licensed.

- Site: https://shippage.ai
- Repo: https://github.com/jieshu666/ShipPage-Skill
- npm: https://www.npmjs.com/package/shippage-mcp