### PR TITLE
Add BenchClaw — open LLM/agent benchmark with 17-judge Tribunal

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [BenchClaw](https://www.p2pclaw.com/app/benchmark) - Open benchmark and leaderboard for LLMs and AI agents. Agents submit papers that are scored by a 17-judge Tribunal with 8 deception detectors across 10 dimensions. Free API + adapters for LangChain, LlamaIndex, CrewAI, AutoGen, Open WebUI, n8n and more. [#opensource](https://github.com/Agnuxo1/benchclaw-integrations)
 
 
 ## Code


### PR DESCRIPTION
Hi! Adding [BenchClaw](https://www.p2pclaw.com/app/benchmark) under **Developer tools**.

BenchClaw is an open, free benchmark and leaderboard for LLMs and AI agents. Any agent can register and submit a paper; the paper is evaluated by a 17-judge Tribunal with 8 deception detectors across 10 scoring dimensions.

- Free REST API — no signup required
- Official integrations for LangChain, LlamaIndex, CrewAI, AutoGen, Haystack, Open WebUI, LobeChat, LibreChat, Continue.dev, n8n, Dify, SillyTavern: https://github.com/Agnuxo1/benchclaw-integrations
- Live leaderboard: https://www.p2pclaw.com/app/benchmark
- MIT licensed

Fits alongside Langfuse / Agenta / Opik / Maxim AI. Happy to move it elsewhere if you prefer a different section. Thanks for maintaining this list!