### PR TITLE
Add Elvean to Chatbots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Gali Chat](https://www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
 - [DeepSeek-R1](https://www.deepseek.com) - *[reviews](https://altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
 - [dmwithme](https://dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
+- [Elvean](https://elvean.app) - Native AI workspace for macOS with agentic tools, interactive charts, MCP servers, Apple Maps, Calendar, and WeatherKit integration.
 
 
 ### Search engines


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** Elvean
- **Description:** Native AI workspace for macOS with agentic tools, interactive charts, MCP servers, Apple Maps, Calendar, and WeatherKit integration.
- **Tool URL:** https://elvean.app
- **Altern.ai page link:** N/A

## Description
Added Elvean to the Chatbots section.

## Checklist
- [x] I have read the Contribution Guidelines
- [x] Only one tool is modified in this PR
- [x] All required fields (name, description, URL) are provided
- [x] The tool link is valid and accessible
- [x] The tool is not already listed
- [x] The tool is placed in the correct category
- [x] The tool is added at the end of its category
- [x] No unrelated changes included in this PR

## Type of Change
- [x] Adding a new AI tool