### PR TITLE
Add grugbot420 to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
 
 
+- [grugbot420](https://github.com/grug-group420/grugbot420) - A neuromorphic cognitive engine in Julia for multi-model AI orchestration. Deploys domain-expert AI specimens through configuration rather than training. [#opensource](https://github.com/grug-group420/grugbot420)
 ## Code
 
 - [GitHub Copilot](https://github.com/features/copilot) - GitHub Copilot uses the OpenAI Codex to suggest code and entire functions in real-time, right from your editor.


### PR DESCRIPTION
## Add grugbot420 — neuromorphic AI engine

[grugbot420](https://github.com/grug-group420/grugbot420) is a neuromorphic cognitive engine written in Julia for multi-model AI orchestration through architectural configuration.

- Open source (MIT), actively maintained
- [Research paper](https://github.com/grug-group420/grugbot420-paper)
- [Interactive playground](https://grug-group420.github.io/portal#playground)

Added to Developer tools section with `#opensource` tag.