### PR TITLE
Add Claude API Cost Calculator to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
+- [Claude API Cost Calculator](https://claudeapipricing.com) - Interactive calculator for estimating Claude API costs across Opus 4, Sonnet 4, and Haiku 3.5, including prompt caching and Batch API savings.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
 - [Keploy](https://keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.
 - [LangChain](https://langchain.com/) - A framework for developing applications powered by language models.


### PR DESCRIPTION
Developers integrating Claude need to estimate API costs before choosing a model tier or designing their token usage strategy. This tool provides an interactive breakdown of costs across all current Claude models (Opus 4, Sonnet 4, Haiku 3.5), including the savings achievable through prompt caching and the Batch API.

Fits the Developer tools section alongside existing entries as a practical planning resource for teams starting a Claude integration or optimising an existing one.

Free to use, no sign-up required. Added after co:here in the Developer tools subsection.