### PR TITLE
Add wick - AI-first Go framework for internal tools and background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [wick](https://yogasw.github.io/wick/) - AI-first Go framework for building internal tools and background jobs — just prompt, AI does the rest. [#opensource](https://github.com/yogasw/wick)
 
 
 ## Code


### PR DESCRIPTION
### What's changed

Add [wick](https://yogasw.github.io/wick/) to **Text → Developer tools**.

> AI-first Go framework for building internal tools and background jobs — just prompt, AI does the rest.

### Why

Wick is a Go framework where AI agents generate self-registering tool and job modules — admin UI, runtime-editable config, and tag-based access control come out of the box. Fits alongside LangChain, Haystack, Plandex, and VoltAgent in the Developer tools list as an AI-first application framework for the Go ecosystem.

### Links

- Docs: https://yogasw.github.io/wick/
- Repo: https://github.com/yogasw/wick
- License: MIT
- Latest release: v0.2.0
