### PR TITLE
Add HeyVid to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
 - [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
 - [Sisif](https://sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
+- [HeyVid](https://heyvid.ai/) - An all-in-one AI video and image generator.
 
 
 ### Animation


### PR DESCRIPTION
Adding HeyVid to the Video category.

- **Name:** HeyVid
- **Link:** https://heyvid.ai/
- **Description:** An all-in-one AI video and image generator.

Entry appended to the end of the Video section, following the existing `- [Name](URL) - Description.` format used throughout the list.