### PR TITLE
Add Docsmith (AI docs generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Docsmith](https://docsmithai.com) - AI-generated documentation websites from GitHub repos. Markdown-first, one-time $19.
 
 
 ## Code


### PR DESCRIPTION
Adding Docsmith to the Developer tools subsection. One-time paid AI tool that generates docs sites from repos.