### PR TITLE
Add tteg to Developer tools (stock photos for AI coding agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [tteg](https://tteg.kushalsm.com) - Stock photos for AI coding agents — real Unsplash images via CLI, HTTP API, or MCP, no API key required. Drop-in replacement for placeholder image URLs in AI-generated landing pages. [#opensource](https://github.com/kiluazen/tteg)
 
 
 ## Code


### PR DESCRIPTION
### What this adds

One entry under **Text → Developer tools** at the bottom of the existing list:

```markdown
- [tteg](https://tteg.kushalsm.com) - Stock photos for AI coding agents — real Unsplash images via CLI, HTTP API, or MCP, no API key required. Drop-in replacement for placeholder image URLs in AI-generated landing pages. [#opensource](https://github.com/kiluazen/tteg)
```

### Why it fits

`tteg` is a developer tool aimed specifically at AI coding agents. Every AI-generated landing page tends to ship with `placehold.co`, `via.placeholder.com`, or the deprecated `source.unsplash.com/random` (the latter is present in **16k+ live GitHub files** as of April 2026 and silently 503s in production). tteg gives agents a one-line recipe (`tteg save "<query>" ./public/<name>`) to replace those with real Unsplash photos, with no API key setup.

### Formatting

- Matches existing entries: `[Name](link) - Description.` ending with a period.
- `[#opensource](...)` badge for the public MIT-licensed GitHub repo.
- Appended to the bottom of the existing section — no reordering.

### Links

- Landing: https://tteg.kushalsm.com
- Source: https://github.com/kiluazen/tteg (MIT)
- Free scanner: https://tteg.kushalsm.com/scan
- Research note: https://github.com/kiluazen/tteg/blob/main/RESEARCH.md

Happy to move to a different sub-section or adjust the wording.