### PR TITLE
Add Scrupp to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[Scrupp](https://scrupp.com/)** - #1 Sales Navigator Scraper Chrome extension. Export 2,500 LinkedIn/Sales Navigator leads to CSV with verified emails and phones. Free plan.
 
 
 ### Phone Calls


### PR DESCRIPTION
Adds [Scrupp](https://scrupp.com/) to the **Marketing AI Tools** section.

Scrupp is a Chrome extension that scrapes LinkedIn and Sales Navigator, then uses an AI-assisted waterfall across multiple data providers to return SMTP-verified work emails and direct phone numbers. It fits alongside Clearbit (lead enrichment peer already listed) and is actively used by 5,000+ SDR teams for outbound prospecting.

Free plan with 100 exports included — no credit card required.