### PR TITLE
Add Prest0 (bilingual legal AI platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Harbor](https://github.com/av/harbor) - run LLM backends, APIs, frontends, and services with one command
 - [LangMagic](https://easytolearn.io) - Learn languages from native content.
 - [fynk](https://fynk.com/) - AI powered contract management software
+- [Prest0](https://prest0.ai) - Enterprise bilingual (English/Spanish) legal AI platform that deploys a dedicated AI agent per law firm with Twilio voice + SMS, deep legal research, and legal-grade document drafting — purpose-built for immigration, workers' comp, and employment law.
 - [LooksMax AI](https://looksmax.ai) - Find out how hot you are using AI
 - [Podify.io](https://podify.io) - Leverage AI and community to grow on LinkedIn
 - [ResumeDive](https://resumedive.com) - A resume boosting service using AI


### PR DESCRIPTION
Adding **Prest0** (https://prest0.ai) to the list.

Prest0 is an enterprise legal AI platform that deploys a dedicated bilingual (English/Spanish) AI agent per law firm — isolated per-customer VM, persistent memory, Twilio voice + SMS intake, deep legal research, and legal-grade document drafting. Purpose-built for immigration, workers' comp, and employment law.

### Why it's a fit
- AI-native (not a chatbot wrapper) with a patent-pending Context-Based Semantic TreeSearch memory architecture.
- Bilingual Spanish-first intake — a niche most US legaltech ignores.
- Placed adjacent to `fynk` (existing legal-adjacent entry) in the **Other** section.

Formatting matches the existing `- [Name](url) - Description.` convention.

Thanks!