### PR TITLE
Add AI Dictation to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [AI Dictation](https://aidictation.com/) - Speech-to-text dictation for Mac that auto-switches between offline and online engines, with AI cleanup that removes filler words, fixes grammar, and formats text per app.
 
 
 ### Meeting assistants


### PR DESCRIPTION
Adds [AI Dictation](https://aidictation.com/) — macOS speech-to-text app that auto-switches between offline and online engines, with AI cleanup that removes filler words, fixes grammar, and formats text per app. Free tier (2,000 words/month, no account required); Pro $8.49/mo or $199.99 lifetime.