### PR TITLE
Add EnigmAgent — local encrypted vault for AI agent secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
 
+- [EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) - Local AES-256-GCM encrypted vault for AI agents. Store API keys and reference them as `{{PLACEHOLDER}}` tokens — secrets resolved at runtime, never exposed to the LLM. Zero cloud, MIT licensed. [#opensource](https://github.com/Agnuxo1/EnigmAgent)
 
 ## Code
 


### PR DESCRIPTION
Adding [EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) to the **Developer tools** section.

**EnigmAgent** is a local AES-256-GCM encrypted vault for AI agents. Store API keys and reference them as `{{PLACEHOLDER}}` tokens in agent prompts — secrets are resolved at runtime so the LLM never sees real values.

- MIT licensed, open source, zero cloud, zero telemetry
- AES-256-GCM encryption + Argon2id key derivation
- Works with Claude Desktop, n8n, LangChain, Open WebUI, Jan, and more via MCP
- Browser extension + npm package (`npx enigmagent-mcp`) + Python package
- Runs locally on Windows, macOS, and Linux

GitHub: https://github.com/Agnuxo1/EnigmAgent