### PR TITLE
Add Van Permit Audit — AI building permit compliance checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AnkiDecks AI](https://anki-decks.com) - Create Flashcards 10x faster. Generate Anki Flashcards from any File or Text with AI.
 - [AI for Google Slides](https://www.aiforgoogleslides.com/) - AI presentation maker for Google Slides
 - [FARSITE](https://far.site/) - AI-powered Compliance Software for U.S. Government Contractors
+- [Van Permit Audit](https://www.vanpermitaudit.com) - AI compliance checker for Vancouver, Canada building permits — validates permit applications against City bylaws instantly.
 - [GOSH](https://gosh.app) - Free AI Price Tracker - Track any price of any product at any store using AI
 - [BrainSoup](https://www.nurgo-software.com/products/brainsoup) Multi-agent & multi-LLM native client where AIs can remember, react to events, use tools, leverage local and external resources, and work together autonomously.
 - [MindPal](https://mindpal.space/) - Build your AI Second Brain with a team of AI agents and multi-agent workflow


### PR DESCRIPTION
## What this adds

- **[Van Permit Audit](https://www.vanpermitaudit.com)** — AI compliance checker for Vancouver, Canada building permits. Validates permit PDFs against City of Vancouver bylaws (Zoning By-law, Vancouver Building By-law 2025, Parking By-law, etc.) and returns a structured pass/fail compliance report.

## Why it fits here

Placed after FARSITE (existing AI compliance entry) in the Productivity section — both are AI-powered regulatory compliance tools. Van Permit Audit is geographically specific to Vancouver, Canada.

## Format

Follows existing list format: `- [Name](url) - Description`