### PR TITLE
Add FuturMix to Developer tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine-tune LLM, CV, and tabular models.
 - [Prediction Guard](https://www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.
 - [Portkey](https://portkey.ai/) - Full-stack LLMOps platform to monitor, manage, and improve LLM-based apps.
+- [FuturMix](https://futurmix.ai) - Unified AI API gateway providing access to 22+ models (OpenAI, Anthropic, Google) through a single OpenAI-compatible endpoint with 99.99% SLA and automatic failover.
 - [OpenAI Downtime Monitor](https://status.portkey.ai/) - Free tool that tracks API uptime and latencies for various OpenAI models and other LLM providers.
 - [ChatWithCloud](https://chatwithcloud.ai/) - CLI allowing you to interact with AWS Cloud using human language inside your Terminal.
 - [SinglebaseCloud](https://singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.


### PR DESCRIPTION
## Summary

- Adds [FuturMix](https://futurmix.ai) to the **Developer tools** section, alongside Portkey and other LLM infrastructure tools
- FuturMix is an enterprise AI agent platform providing access to 22+ models (OpenAI, Anthropic, Google) with 99.99% SLA and automatic failover

## Entry

```
- [FuturMix](https://futurmix.ai) - enterprise AI agent platform providing access to 22+ models (OpenAI, Anthropic, Google) with 99.99% SLA and automatic failover.
```

Follows the existing entry format (name with link + hyphen + description).