### PR TITLE
Add Natalia and Recapro

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Sybill](https://www.sybill.ai/) - Sybill generates summaries of sales calls, including next steps, pain points and areas of interest, by combining transcript and emotion-based insights.
 - [Loopin AI](https://www.loopinhq.com/) - Loopin is a collaborative meeting workspace that not only enables you to record, transcribe & summaries meetings using AI, but also enables you to auto-organise meeting notes on top of your calendar.
 - [Scribbl](https://www.scribbl.co) - AI Meeting Notes
-- [Recapro](https://recapro.ai/) - AI-powered meeting transcription and structured report generation. Converts voice recordings into actionable summaries tailored by meeting type. iOS/Android apps with offline recording. CRM integration (Salesforce, SharePoint, SAP). GDPR compliant. Hosted in France.
+- [Recapro](https://recapro.ai/) - Meeting transcription and structured report generation. Converts recordings into summaries adapted to each meeting type (sales, support, project). iOS/Android apps with offline recording. CRM integration (Salesforce, SharePoint, SAP). GDPR compliant. Hosted in France.
 
 ### Academia
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Sybill](https://www.sybill.ai/) - Sybill generates summaries of sales calls, including next steps, pain points and areas of interest, by combining transcript and emotion-based insights.
 - [Loopin AI](https://www.loopinhq.com/) - Loopin is a collaborative meeting workspace that not only enables you to record, transcribe & summaries meetings using AI, but also enables you to auto-organise meeting notes on top of your calendar.
 - [Scribbl](https://www.scribbl.co) - AI Meeting Notes
+- [Recapro](https://recapro.ai/) - AI-powered meeting transcription and structured report generation. Converts voice recordings into actionable summaries tailored by meeting type. iOS/Android apps with offline recording. CRM integration (Salesforce, SharePoint, SAP). GDPR compliant. Hosted in France.
 
 ### Academia
 
@@ -471,6 +472,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI Voice Agents](https://diallink.com/) — AI Voice Agents for business calls and routine tasks, powered by DialLink cloud phone system.
 - [Cald.ai](https://cald.ai) - AI based calling agents for outbound and inbound phone calls.
 - [Rosie](https://heyrosie.com/) - AI Phone Answering Service
+- [Natalia](https://getnatalia.com/) - AI voice assistant for incoming business calls. Answers in under 2 seconds, qualifies callers, transfers to the right person or captures messages. WhatsApp rebounding for missed calls. CRM integration (Salesforce, HubSpot, Pipedrive). Hosted in France.
 
 ### Speech
 - [Eleven Labs](https://beta.elevenlabs.io/) - AI voice generator.


### PR DESCRIPTION
Add two AI tools hosted in France:

- **Natalia** (https://getnatalia.com) — AI voice assistant for incoming business calls. Added to the **Phone Calls** section.
- **Recapro** (https://recapro.ai) — Meeting transcription and structured report generation. Added to the **Meeting assistants** section.