### PR TITLE
Add Slate AI learning platform to Other AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Socialsonic](https://socialsonic.com) - AI LinkedIn Coach: Personalized content, trends & scheduling.
 - [Napkin](https://www.napkin.ai/) - Napkin turns your text into visuals so sharing your ideas is quick and effective.
 - [Exam Samurai](https://www.examsamur.ai/) - AI Exam Generator
+- - [Slate](https://slateup.ai) – AI-powered interactive learning platform. Generate a course on any topic and learn with AI classmates who ask questions, test your understanding, and adapt to your pace.
 - [AI Watermark Remover](https://aiwatermarkremover.io/) - Remove watermarks from images and videos.
 - [AISaver](https://aisaver.io) - Collection of AI Powered Video and Photo Tools
 - [Harbor](https://github.com/av/harbor) - run LLM backends, APIs, frontends, and services with one command


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** Slate
- - **Description:** AI-powered interactive learning platform where you generate a course on any topic and learn with AI classmates.
- - **Tool URL:** https://slateup.ai
- - **Altern.ai page link:** (not yet listed)
## Description
Added Slate to the Other AI Tools section. Slate is an AI-powered interactive classroom where learners generate courses on any topic and study with AI classmates who ask questions, test understanding, and adapt to individual pace. It replaces passive video content with active, retrieval-based learning.

## Checklist
- [x] I have read the Contribution Guidelines
- [ ] - [x] Only one tool is modified in this PR
- [ ] - [x] All required fields (name, description, URL) are provided
- [ ] - [x] The tool link is valid and accessible