### PR TITLE
Add AIFast Hub to AI tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 ### Chatbots
 
 - [ChatGPT](https://chatgpt.com) - *[reviews](https://theresanai.com/chatgpt)* - ChatGPT by OpenAI is a large language model that interacts in a conversational way.
+- [Aifast](https://www.aifast.club) - Fast and stable AI API service providing access to Claude 3.5 Sonnet, GPT-4o, and more, optimized for users in China.
 - [Bing Chat](https://www.bing.com/chat) - *[reviews](https://altern.ai/product/bing_chat)* - A conversational AI language model powered by Microsoft Bing.
 - [Gemini](https://gemini.google.com) - *[reviews](https://altern.ai/product/gemini)* - An experimental AI chatbot by Google, powered by the LaMDA model.
 - [Character.AI](https://character.ai/) - *[reviews](https://altern.ai/product/character-ai)* - Character.AI lets you create characters and chat to them.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 ### Chatbots
 
 - [ChatGPT](https://chatgpt.com) - *[reviews](https://theresanai.com/chatgpt)* - ChatGPT by OpenAI is a large language model that interacts in a conversational way.
-- [AIFast Hub](https://www.aifast.club) - OpenAI-compatible API access to models listed in its current catalog; availability should be checked in the console and maintenance notices.
 - [Bing Chat](https://www.bing.com/chat) - *[reviews](https://altern.ai/product/bing_chat)* - A conversational AI language model powered by Microsoft Bing.
 - [Gemini](https://gemini.google.com) - *[reviews](https://altern.ai/product/gemini)* - An experimental AI chatbot by Google, powered by the LaMDA model.
 - [Character.AI](https://character.ai/) - *[reviews](https://altern.ai/product/character-ai)* - Character.AI lets you create characters and chat to them.
@@ -232,6 +231,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Developer tools
 
+- [AIFast Hub](https://www.aifast.club) - OpenAI-compatible API access to models listed in its current catalog; availability should be checked in the console and maintenance notices.
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 ### Chatbots
 
 - [ChatGPT](https://chatgpt.com) - *[reviews](https://theresanai.com/chatgpt)* - ChatGPT by OpenAI is a large language model that interacts in a conversational way.
-- [Aifast](https://www.aifast.club) - Fast and stable AI API service providing access to Claude 3.5 Sonnet, GPT-4o, and more, optimized for users in China.
+- [AIFast Hub](https://www.aifast.club) - OpenAI-compatible API access to models listed in its current catalog; availability should be checked in the console and maintenance notices.
 - [Bing Chat](https://www.bing.com/chat) - *[reviews](https://altern.ai/product/bing_chat)* - A conversational AI language model powered by Microsoft Bing.
 - [Gemini](https://gemini.google.com) - *[reviews](https://altern.ai/product/gemini)* - An experimental AI chatbot by Google, powered by the LaMDA model.
 - [Character.AI](https://character.ai/) - *[reviews](https://altern.ai/product/character-ai)* - Character.AI lets you create characters and chat to them.


### PR DESCRIPTION
Adds one evergreen AIFast Hub entry under Developer tools. It is an OpenAI-compatible API platform rather than a chatbot. The entry avoids fixed model versions, model counts, latency, availability, and pricing claims; current model IDs and maintenance state should be checked in the platform console and notices.