### PR TITLE
Add Drevon to Marketing AI Tools and Lead Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[Chatfuel](https://www.chatfuel.com/)** - AI-driven chatbot for automating customer engagement on Messenger.
 - **[LogicBalls](https://logicballs.com/)** - An AI-powered writing tool to create any type of content and supercharge your productivity.
 - **[Rupert AI](https://www.getrupert.com/)** - AI tools for designers and marketers
+- **[Drevon](https://drevon.dev)** - Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel from LinkedIn, CRM, and sales tools.
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes


### PR DESCRIPTION
Adds [Drevon](https://drevon.dev/) to the **Marketing AI Tools** section of the README, and to the **Lead Generation** section of `marketing.md`.

Drevon is a Mac app for sales and GTM research. AI agents run inside the user's own browser, using the Claude, ChatGPT, or Copilot subscription they already pay for, and return lead lists, account briefs, and competitor trackers. Because the browsing happens locally rather than from a data center, it reaches the sources the user is already logged into.

**Website:** https://drevon.dev/
**Platform:** macOS
**Category:** Marketing AI Tools / Lead Generation

Two entries, two lines. I reworded the original README line in this PR to drop jargon and match the plain-language style of the surrounding entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)