### PR TITLE
Add AgentKit to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [AgentKit](https://github.com/MukundaKatta/agentkit) - The agent reliability stack in one install: token-aware truncation (fit), egress firewall (guard), tool-call snapshot tests (snap), arg validation (vet), and structured-output enforcement (cast). [#opensource](https://github.com/MukundaKatta/agentkit)
 
 
 ## Code


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** AgentKit
- **Description:** The agent reliability stack in one install (fit, guard, snap, vet, cast).
- **Tool URL:** https://github.com/MukundaKatta/agentkit

## Description
Added AgentKit to the "Developer tools" section. AgentKit is a single install that wires together five small primitives for shipping reliable LLM agents:
- `agentfit` (token-aware message truncation),
- `agentguard` (network-egress firewall for tool calls),
- `agentsnap` (snapshot tests for tool-call traces),
- `agentvet` (validate tool args before execution),
- `agentcast` (validate-and-retry loop for structured output).

Each is also published standalone on npm; AgentKit is the meta-package.

## Checklist
- [x] Only one tool is modified in this PR
- [x] All required fields provided
- [x] The tool link is valid and accessible
- [x] The tool is not already listed (grepped repo)
- [x] Placed in the correct category (Developer tools)
- [x] Added at the end of the category
- [x] No unrelated changes

## Type of Change
- [x] Adding a new AI tool