### PR TITLE
Add TokenMix to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
+- [TokenMix](https://tokenmix.ai/) - One API key for GPT-5, Claude, Gemini, DeepSeek and 155+ LLMs through an OpenAI-compatible endpoint. Open-source SDKs in 10+ languages.
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.


### PR DESCRIPTION
Hi! Adding [TokenMix](https://tokenmix.ai) to the **Developer tools** section.

TokenMix gives developers access to GPT-5, Claude, Gemini, DeepSeek and 155+ LLMs through one OpenAI-compatible API key — directly comparable to the existing AI/ML API entry. Free $1 credit on signup.

Open-source SDKs in 10+ languages (Python, Node.js, Rust, Go, Ruby, Java, .NET, PHP, Swift).