### PR TITLE
Add pdfmux to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
 
 
+- [pdfmux](https://pdfmux.com) - Open-source PDF extraction orchestrator. Routes each page to the best of 5 backends (PyMuPDF, OpenDataLoader, RapidOCR, Docling) with optional BYOK LLM fallback. Per-page confidence scoring catches and re-extracts failures. Ranks #2 on opendataloader-bench. Built-in MCP server. [#opensource](https://github.com/NameetP/pdfmux)
+
 ## Code
 
 - [GitHub Copilot](https://github.com/features/copilot) - GitHub Copilot uses the OpenAI Codex to suggest code and entire functions in real-time, right from your editor.


### PR DESCRIPTION
Adds [pdfmux](https://pdfmux.com) (MIT, [github.com/NameetP/pdfmux](https://github.com/NameetP/pdfmux)) to **Developer tools**.

**What it is:** PDF extraction orchestrator built for AI/RAG pipelines. Scores every page on 4 quality signals and re-extracts failures with a stronger backend. Built-in MCP server for Claude Desktop / Cursor.

**Why it fits:** Pairs naturally with LangChain / Haystack / Agenta which are already in this section. pdfmux is the upstream layer that gets clean text into RAG pipelines.

**Proof points:**
- Ranks #2 on [opendataloader-bench](https://pdfmux.com/blog/benchmarking-pdf-extractors/) (200 real-world PDFs)
- Listed in [awesome-langchain](https://github.com/kyrolabs/awesome-langchain) (9.3k★), [RAGHub](https://github.com/Andrew-Jang/RAGHub), [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) (85k★)
- MIT, pip install, BYOK LLM