### PR TITLE
Add lean-ctx to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
 - [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
 - [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
-- [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click. 
+- [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click.
+- [lean-ctx](https://leanctx.com) - Open-source context runtime for AI coding agents. MCP server reducing token costs by 60-99%. 46 tools, session caching, AST-aware compression. Single Rust binary. Apache-2.0. 900+ stars, 32k+ installs. [#opensource](https://github.com/yvgude/lean-ctx)
 - [StarOps](https://ingenimax.ai) - AI Platform Engineer
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.


### PR DESCRIPTION
Adds [lean-ctx](https://leanctx.com) ([source](https://github.com/yvgude/lean-ctx)) to the Developer tools section — open-source MCP context runtime for AI coding agents (token savings, session caching, AST-aware compression).