### PR TITLE
Add UGCFast to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
 - [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
 - [Sisif](https://sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
+- - [UGCFast](https://ugcfast.ai/) - AI UGC video ad generator with 300+ AI actors and 35+ languages — built for performance marketers shipping TikTok, Reels, and Meta ads.
 
 
 ### Animation


### PR DESCRIPTION
Adds UGCFast — an AI UGC video ad generator with 300+ AI actors and 35+ languages. It targets performance marketers and DTC e-commerce teams replacing human creators for TikTok, Instagram Reels, and Meta video ads. Fits the Video section alongside HeyGen, D-ID, ShortVideoGen.

## 📝 New Tool Information
- **Tool Name:** UGCFast
- **Description:** AI UGC video ad generator with 300+ AI actors across 35+ languages — built for performance marketers shipping TikTok, Reels, and Meta ads.
- **Tool URL:** https://ugcfast.ai/
- **Altern.ai page link:** (not applicable)

## 📌 Description
Added a new entry under the **## Video** section, placed at the end of the existing list (after Sisif), per the contribution guideline of appending new entries to their category.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠️ Type of Change
- [x] ➕ Adding a new AI tool
