### PR TITLE
Add Skilly under Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [Skilly](https://tryskilly.app) - Voice-first AI tutor for Mac that watches your screen and walks you through any app (Blender, Figma, Xcode, Photoshop) in real time. Built on OpenAI Realtime API + ScreenCaptureKit. Open source under Apache-2.0. 20+ languages with auto-detect.
 
 
 ### Meeting assistants


### PR DESCRIPTION
Adds [Skilly](https://tryskilly.app) under **Text > Productivity**.

Voice-first AI tutor for Mac that watches your screen and walks you through any app (Blender, Figma, Xcode, Photoshop, etc.) out loud. Press a hotkey, ask a question aloud, and Skilly screenshots your active app, narrates the answer, and points your cursor at the exact UI element.

**Stack:** native Swift, ScreenCaptureKit, NSPanel-on-every-space, OpenAI Realtime API. macOS 14.2+. 20+ languages with auto-detect (incl. Arabic RTL, Chinese, Japanese).

**Open source under Apache-2.0:** [github.com/tryskilly/skilly](https://github.com/tryskilly/skilly). Ships with 5 free standalone skill curricula in markdown (Blender, Figma, After Effects, DaVinci Resolve, Premiere Pro — ~33 hours total).

Disclosure: I'm the author. Happy to adjust the description if anything doesn't fit your editorial style.