### PR TITLE
Add WinkTerm - open-source AI terminal with shared PTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 ## Code
 
 - [GitHub Copilot](https://github.com/features/copilot) - GitHub Copilot uses the OpenAI Codex to suggest code and entire functions in real-time, right from your editor.
+- [WinkTerm](https://github.com/Cznorth/winkterm) - Open-source AI terminal where the AI types commands directly into your shell. Features shared PTY session, SSH with file transfer, in-terminal chat, and BYO LLM. [#opensource](https://github.com/Cznorth/winkterm)
 - [poorcoder](https://github.com/vgrichina/poorcoder) - Lightweight Bash scripts that enhance your terminal coding workflow with web-based AI assistants like Claude or Grok without disrupting your development process.
 - [OpenAI Codex](https://platform.openai.com/docs/guides/code/) - An AI system by OpenAI that translates natural language to code.
 - [Ghostwriter](https://blog.replit.com/ai) - An AI-powered pair programmer by Replit.


### PR DESCRIPTION
Adds [WinkTerm](https://github.com/Cznorth/winkterm) to the Code section - an open-source AI terminal where the AI types commands directly into your shell, not just suggests them.

## Why WinkTerm?
- **Shared PTY**: AI and user share the same terminal process
- **SSH + file transfer**: Remote server management built-in
- **BYO LLM**: Bring your own API key (OpenAI, Anthropic, Ollama)
- **Open source**: MIT licensed
- **Quick start**: `docker run ghcr.io/cznorth/winkterm:latest`
- **Demos**: [Promo video](https://github.com/Cznorth/winkterm/raw/master/assets/promo.mp4), [Live website](https://cznorth.github.io/winkterm/)

Check marked as #opensource since the repo includes [#opensource](https://github.com/Cznorth/winkterm) topic.