### PR TITLE
Add PromptEden to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[PromptEden](https://www.prompteden.com)** - AEO (Answer Engine Optimization) monitoring — tracks how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand and which competitors they recommend instead.
 
 
 ### Phone Calls


### PR DESCRIPTION
Adds [PromptEden](https://www.prompteden.com) to **Marketing AI Tools**.

PromptEden monitors how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand — and which competitors they recommend instead. Daily refresh across 9+ AI platforms, surfacing visibility scores, citation sources, and competitor mentions. Sits next to MarketMuse / Phrasee / Mutiny in the marketing-tools spirit, but for the AEO (Answer Engine Optimization) era rather than classical SEO/SEM.