### PR TITLE
Add AI Invoice Maker (AI-powered invoicing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [AI Invoice Maker](https://ainvoicemaker.com/) - Free AI-powered invoice generator with smart payment reminders. Auto-fills invoice fields from natural language, drafts firm-but-polite chase emails, and supports 50+ currencies. No signup, no watermark.
 
 
 ### Meeting assistants


### PR DESCRIPTION
Adds [AI Invoice Maker](https://ainvoicemaker.com/) under **Productivity**.

### Why it fits
- Lives in the same bucket as the existing AI-powered productivity tools in this section (Notion AI, Mem, Taskade, Elephas, etc.)
- AI angle is core: natural-language → structured invoice fill (Smart Paste) + AI-drafted payment reminder emails with adjustable tone
- Free with no signup — useful for solo operators evaluating AI productivity tools without a trial flow

### Entry
- [AI Invoice Maker](https://ainvoicemaker.com/) - Free AI-powered invoice generator with smart payment reminders. Auto-fills invoice fields from natural language, drafts firm-but-polite chase emails, and supports 50+ currencies. No signup, no watermark.

Happy to revise wording or move section if a different placement fits better.