### PR TITLE
Add Lacy Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [StarOps](https://ingenimax.ai) - AI Platform Engineer
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
+- [Lacy Shell](https://github.com/lacymorrow/lacy) - ZSH/Bash plugin that routes natural language to AI agents and commands to the shell. Works with Claude Code, Gemini CLI, OpenCode, Codex. [#opensource](https://github.com/lacymorrow/lacy)
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
 


### PR DESCRIPTION
Add [Lacy Shell](https://github.com/lacymorrow/lacy) to Developer tools.

Lacy is an open-source ZSH/Bash plugin that routes natural language to AI agents and commands to the shell. A real-time color indicator shows routing before you press enter. Works with Claude Code, Gemini CLI, OpenCode, Codex, or any custom AI CLI tool. Sub-millisecond lexical detection, no AI call to classify input.

- MIT licensed
- macOS, Linux, WSL
- ZSH and Bash 4+