### PR TITLE
Add Pyanchor to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [Pyanchor](https://github.com/pyanchor/pyanchor) - Self-hosted live-edit sidecar for Next.js / Vite / Astro apps. Click an element in your running app, describe a UI change in plain text, and a pluggable AI agent (Codex / Claude / Aider / Gemini / Pollinations) edits the source, runs the build, and either reloads the dev server or opens a PR for review. MIT.
 
 
 ## Image


### PR DESCRIPTION
Adds Pyanchor (https://github.com/pyanchor/pyanchor) to the Code section.

Pyanchor is a self-hosted Express sidecar for visual live editing — you point it at a running Next.js / Vite / Astro app, click an element, describe a UI change in plain text, and a pluggable AI agent edits the source, runs the build, and either reloads the dev server or opens a PR for review.

Six interchangeable agent backends behind one env var: Codex, Claude Code, Aider, Gemini, Pollinations, and OpenClaw. The Pollinations option needs no CLI install and no API key (HTTP-only, anonymous-tier rate limit), which makes the demo zero-install. MIT, ~2 runtime deps.