### PR TITLE
Add Knack: curated Claude Code skill packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [Knack](https://knack.run) - Curated catalogue of lifetime-licensed Claude Code skill packs for solo operators and indie hackers. Free starter pack under MIT; paid packs each run an end-to-end workflow system for one role.
 
 
 ### Meeting assistants


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** Knack
- **Description:** Curated catalogue of lifetime-licensed Claude Code skill packs for solo operators and indie hackers.
- **Tool URL:** https://knack.run
- **Altern.ai page link:** (n/a)


## 📌 Description
Adds Knack to the **Productivity** section.

**What it is:** Knack is a curated catalogue of lifetime-licensed Claude Code skill packs. Each pack is a downloadable bundle of skills, slash commands, and agents that drops into Claude Code and runs an end-to-end workflow system for one operator role.

**Free starter pack:** MIT-licensed, two skills (\`idea-clarifier\` + \`first-skill-template\`). https://github.com/knack-run/knack-starter-pack

**Paid catalogue:** £99 lifetime per pack. Solo Consultant Ops (the 7-phase engagement system for independent consultants) is shipped; Indie Hacker Launch (the launch-week system for solo founders) ships Q2 2026.

**Why it fits this list:** Knack sits cleanly alongside the existing entries that focus on AI-assisted developer tooling (Cursor-style products, Claude tooling, etc.). The free MIT starter pack means readers can evaluate the catalogue with zero cost.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---


## 🛠 Type of Change
- [x] 📚 Documentation / README update
- [x] ➕ Adding a new AI tool
- [ ] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix