### PR TITLE
Add Friday to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [Friday](https://hellofriday.ai/) ([friday-platform/friday-studio](https://github.com/friday-platform/friday-studio)) - Self-hosted, local-first AI agent runtime that turns natural-language asks into repeatable, versioned workflows wired to MCP tools, skills, memory, and signals (HTTP, cron, Slack, email, webhook).
 
 
 ### Meeting assistants


### PR DESCRIPTION
## Summary
- Adds [Friday](https://hellofriday.ai/) ([friday-platform/friday-studio](https://github.com/friday-platform/friday-studio)) to the Productivity section.
- Friday is a self-hosted, local-first AI agent runtime that turns natural-language asks into repeatable, versioned workflows — agents, MCP tools, skills, memory, and signals (HTTP, cron, Slack, email, webhook) wired together. Local-first daemon + SvelteKit playground; one-click macOS installer.

## Test plan
- [x] Markdown renders correctly
- [x] Links resolve (homepage + repo)
- [x] Entry placed in the most relevant existing section (Productivity, alongside Taskade / Nekton AI / MindPal)