### PR TITLE
Add Letterfork to Writing assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [DeepL Write](https://www.deepl.com/write) - AI writing tool that improves written communication.
 - [Headlinesai.pro](https://www.headlinesai.pro/) - This AI powered tool can help you in generating catchy and optimized headlines based on your content for multiple platforms like Youtube, Medium, Indie Hackers and Reddit.
 - [GPTLocalhost](https://gptlocalhost.com/demo/) - A local Word Add-in for you to use local LLM servers in Microsoft Word. Alternative to "Copilot in Word" and completely local.
+- [Letterfork](https://letterfork.com) - AI rewrites a newsletter into 7 platform-native social posts (LinkedIn, X, Bluesky, Substack Notes, Threads, Instagram, Reddit) in your own writing voice. Voice cloning learns from your past writing; no auto-publishing.
 
 
 ### ChatGPT extensions


### PR DESCRIPTION
Adds Letterfork to **Text → Writing assistants**.

Letterfork is a newsletter-to-7-platforms AI rewriter built specifically for newsletter writers (Substack, Beehiiv, Ghost). Paste a URL — get 7 platform-native social posts (LinkedIn, X, Bluesky, Substack Notes, Threads, Instagram, Reddit) in the writer's own voice in ~60s.

It's narrower than the general-purpose writing assistants already on the list (Jasper, copy.ai, Rytr) and focuses on the cross-platform repurposing wedge: voice-cloning trained on the writer's own past content + format rules per platform (Bluesky 300-char chains, LinkedIn hook-led single-sentence paragraphs, Notes ending in a stance/question, Reddit in member-not-marketer tone).

Free tier: 3 lifetime rewrites, all 7 platforms, no credit card — readers of this list can validate the entry without sign-up.

Live: https://letterfork.com