### PR TITLE
Add ViralMint to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
 - [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
 - [Sisif](https://sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
+- [ViralMint](https://github.com/openclaw-easy/ViralMint) - Scout trending YouTube/TikTok/Douyin videos, analyze competitors with Whisper, generate originals with AI script, voice, captions and music. Desktop app, AGPL-3.0.
 
 
 ### Animation


### PR DESCRIPTION
Adding **ViralMint** to the **📽️ Generative AI Video** section.

**Project:** https://github.com/openclaw-easy/ViralMint
**Website:** https://viralmint.net
**License:** AGPL-3.0
**Platforms:** macOS / Windows / Linux

ViralMint is a creator pipeline that combines three steps usually split across separate tools:

1. **Scout** — multi-platform trend discovery across YouTube, TikTok, Douyin, Reddit and Google Trends, with a 0–100 virality score and channel-baseline outlier detection (3×–20× breakouts).
2. **Analyze** — local Whisper transcription + AI extraction of hook, structure, tone and angle from any downloaded competitor video.
3. **Generate** — AI script (transcript-aware) + AI voice + word-by-word animated captions + AI music + Pexels stock footage stitched into a finished mp4.

Output is an unwatermarked mp4 plus AI-drafted titles, descriptions and tags so creators can post manually. Free daily allowance, no subscription.

Distinguishes itself in this section as a **full creator pipeline** (scout + analyze + generate) rather than a single-purpose video generator like RunwayML/Synthesia or single-purpose clipper like Clipwing — which is reflected in the description.

Inserted at the end of the Video section to preserve existing entry order.