### PR TITLE
Add MeMakie AI Tools Index to Editor's Choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ## Editor's Choice
 
+- [MeMakie AI Tools Index](https://memakie.com/tools) - Editorial directory of 1,300+ AI chat, character, voice, image, and writing tools with automated AI curation, verdicts, screenshots, and pros/cons. Free, no signup.
 - [AI For Developers](https://aifordevelopers.org) - Just a curated list of AI agents, SDKs, coding copilots, and dev-first tools that save you hours — not waste them.
 - [There's an AI](https://theresanai.com) - List of best AI Tools
 - [Notion AI](https://affiliate.notion.so/9po6cx7rvdr6-4y5a7) - Just ask Q&A, and find the info you need in seconds. Get help writing and brainstorming in Notion, not in a separate browser tab.


### PR DESCRIPTION
Adding MeMakie's AI Tools Index — an editorial directory of 1,300+ AI tools across chat, character, voice, image, video, writing, and agents categories.

Each listing has an editorial verdict, feature flags (memory / voice / group chat / NSFW policy), pricing, and a homepage screenshot. Curation is automated via a two-LLM pipeline: Llama 3.3 70B drafts each listing, Claude Haiku flags ones needing rewrite, and Claude Sonnet independently re-scrapes the homepage and rewrites the flagged ones (or declines if it disagrees with the editor).

Free to browse, no signup. Same lane as the other directories already in Editor's Choice (e.g. There's an AI).