### PR TITLE
Add Awesome AI Startups to Related Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Awesome Workflow Automation](https://github.com/dariubs/awesome-workflow-automation) - Curated List of Workflow Automation Apps And Tools
 - [Awesome Marketing](https://github.com/marketingtoolslist/awesome-marketing)
 - [Top AI Directories](https://github.com/best-of-ai/ai-directories) - An awesome list of best top AI directories to submit your ai tools
+- [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) - A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders
 
 
 created by [Mahsima Dastan](https://github.com/mahseema)


### PR DESCRIPTION
Adds [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) to the **Related Awesome Lists** section.

It's a curated list of indie-built AI startups — bootstrapped, pre-seed, and angel-funded products only — covering 18 categories (AI Agents, Coding, Marketing, Audio/Voice, Image/Design, etc.) with ~440 entries.

Followed contributing conventions: matched the section's existing entry format and added at the bottom of the section.