### PR TITLE
Add Tokenometer — LLM cost CLI + GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Developer tools
 
+- [Tokenometer](https://github.com/faraa2m/tokenometer) - LLM token cost + latency CLI + GitHub Action + VS Code extension + Claude Code skill. Multi-provider (Claude, GPT-4o, Gemini, Mistral, Cohere). Empirical mode, CI-native cost guardrail.
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.


### PR DESCRIPTION
Adds Tokenometer to the appropriate section.

**Tokenometer** — empirical LLM token-cost CLI + GitHub Action + VS Code / Cursor extension + Claude Code skill. Multi-provider (Claude, GPT-4o, Gemini, Mistral, Cohere), offline + empirical modes, CI cost-guardrail with sticky PR comments and budget gates.

- Repo: https://github.com/faraa2m/tokenometer
- npm: `npx tokenometer ./prompt.md --model claude-opus-4-7`
- GitHub Marketplace: https://github.com/marketplace/actions/tokenometer
- Live demo: https://tokenometer.vercel.app
- VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=faraa2m.tokenometer-vscode

If the placement is in the wrong section happy to adjust.