### PR TITLE
Add great_cto to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [great_cto](https://github.com/avelikiy/great_cto) - 34-agent SDLC orchestrator with 25 archetype auto-detection and compliance gates (PCI-DSS, HIPAA, GDPR). Multi-platform — runs in Claude Code, Cursor, Codex CLI, Aider, Continue. Local kanban board, OWASP LLM Top 10 scanner, MIT.
 
 
 ## Image


### PR DESCRIPTION
Adding [great_cto](https://github.com/avelikiy/great_cto) to **## Code**.

34-agent SDLC orchestrator: architect, pm, senior-dev, code-reviewer, qa, security, devops, l3-support + 18 archetype-specific reviewers. Auto-detects 25 project archetypes (web-service, fintech, healthcare, mlops, web3, edtech, gov-public, etc) with compliance gates. Runs in Claude Code, Cursor, Codex CLI, Aider, Continue (one config). Local kanban board, OWASP LLM Top 10 scanner, MIT licensed.

Inserted at end of Code section.