### PR TITLE
Add Beton to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[Beton](https://www.getbeton.ai/)** - Open-source AI revenue intelligence. Auto-detects buying, expansion, and churn signals from PostHog product usage and routes them to your CRM (Attio, HubSpot, Pipedrive). Self-host AGPLv3 or managed cloud.
 
 
 ### Phone Calls


### PR DESCRIPTION
Adds **Beton** to the **Marketing AI Tools** section.

**Beton** is open-source AI revenue intelligence for product-led B2B SaaS. It connects PostHog product analytics to your CRM (Attio, HubSpot, Zoho, Pipedrive) and auto-detects buying intent, expansion readiness, and churn risk from product usage — no manual rules to configure.

- Website: https://www.getbeton.ai
- GitHub: https://github.com/getbeton/inspector
- License: AGPL-3.0 (self-host free) or managed cloud at $0.50/tracked user/mo
- Differentiates from Clearbit / Mutiny in the same section by sitting on top of an existing product-analytics stack rather than enriching from external data, and from Pocus / MadKudu / Common Room by being open-source with autopilot signal discovery instead of rule-based scoring.

Inserted at the end of the Marketing AI Tools list to preserve existing entry order. Happy to move sections or shorten the description if preferred.