### PR TITLE
Add Heimdall MCP to the list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Heimdall MCP](https://stack.cardor.dev/heimdall) - Transparent MCP proxy with OpenTelemetry tracing. Wrap any MCP server, persist traces to SQLite · Postgres · MySQL. No code changes needed.
 
 
 ## Code


### PR DESCRIPTION
## 📝 New Tool Information
Tool Name: heimdall-mcp
Description: Transparent proxy for any MCP server that intercepts all JSON-RPC messages, measures latency, and stores traces in SQLite, PostgreSQL, or MySQL — without modifying the original server.
Tool URL: https://github.com/enmanuelmag/heimdall-mcp
Website: https://stack.cardor.dev/heimdall
Altern.ai page link: (not available yet)

## 📌 Description
Added heimdall-mcp to the MCP Tools / Developer Tools section. It is an open-source CLI proxy that wraps any MCP server (stdio, HTTP, or SSE) and adds observability: OpenTelemetry tracing, Jaeger export, and persistent span storage — with zero changes required to the original server.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---


## 🛠 Type of Change
- [ ] 📚 Documentation / README update
- [x] ➕ Adding a new AI tool
- [ ] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix
- [ ] Other (please specify):

---


## 📷 Screenshots / Demo (if applicable)
<img width="2975" height="1644" alt="image" src="https://github.com/enmanuelmag/heimdall-mcp/blob/master/assets/jaeger.png?raw=true" />

---

## 💡 Additional Notes
heimdall-mcp works by sitting between any MCP client (Claude Desktop, Cursor, OpenCode) and the real MCP server. It supports three transport modes (stdio subprocess, remote HTTP, remote SSE) and a programmatic API (ProxyBuilder) for custom integrations. Spans follow OpenTelemetry gen_ai.* semantic conventions.
