### PR TITLE
Add skill-audit-mcp to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
+- [skill-audit-mcp](https://github.com/eltociear/skill-audit-mcp) - Static security scanner for MCP servers, AI agent skills, and plugins. Detects 68 attack patterns across CRITICAL/HIGH/MEDIUM/LOW — credential exfiltration, prompt injection, code execution, seed-phrase harvest, auth bypass, path traversal. Ships as a GitHub Action, multi-arch Docker image, MCP server, and hosted x402 API. SARIF output for GitHub Code Scanning. [#opensource](https://github.com/eltociear/skill-audit-mcp)
 - [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
 - [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.
 - [Calmo](https://getcalmo.com/) - Debug Production x10 Faster with AI.


### PR DESCRIPTION
Adds [skill-audit-mcp](https://github.com/eltociear/skill-audit-mcp) under **Developer tools**, alongside CodeRabbit and Callstack.ai PR Reviewer.

Where general PR reviewers check application code, skill-audit-mcp specializes in the **MCP server and AI agent skill layer** — the surface where most production prompt-injection and credential-exfiltration attacks ship in 2026.

**Detects 68 attack patterns across 4 severity levels:**

- credential exfiltration / seed-phrase harvest
- prompt injection (instruction override, hidden Unicode, encoded payloads)
- arbitrary code execution
- auth bypass / identity impersonation
- path traversal

**Distribution:**
- GitHub Action: `uses: eltociear/skill-audit-mcp@v1` → SARIF → GitHub Code Scanning
- Multi-arch Docker: `ghcr.io/eltociear/skill-audit-mcp:v1`
- MCP server transport
- Hosted x402 API (pay-per-scan, USDC micropayments on Base)

Open source (MIT), zero dependencies, Python 3.6+. Glama-verified.