### PR TITLE
Add aitells (20 niche AI writing generators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [DeepL Write](https://www.deepl.com/write) - AI writing tool that improves written communication.
 - [Headlinesai.pro](https://www.headlinesai.pro/) - This AI powered tool can help you in generating catchy and optimized headlines based on your content for multiple platforms like Youtube, Medium, Indie Hackers and Reddit.
 - [GPTLocalhost](https://gptlocalhost.com/demo/) - A local Word Add-in for you to use local LLM servers in Microsoft Word. Alternative to "Copilot in Word" and completely local.
+- [aitells](https://aitells.vercel.app/) - 20 single-purpose AI writing generators on hyper-niche URLs (/eulogy, /wedding-vows, /apology-letter, /cover-letter, /salary-negotiation, /obituary, /college-essay etc). One $9 unlocks all 20. Specific > generic.
 
 
 ### ChatGPT extensions


### PR DESCRIPTION
Adding aitells to the Writing assistants section.

aitells: 20 single-purpose AI writing generators, each on its own URL targeting one specific search intent (e.g. /eulogy, /wedding-vows, /apology-letter, /cover-letter, /salary-negotiation, /obituary, /college-essay).

Factory pattern under the hood — one central /api/generate endpoint with 20 templates + a reusable client component. Live since May 2026 at https://aitells.vercel.app/. $9 one-time unlocks all 20 generators.