### PR TITLE
Add AnySlide to Graphic design

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Text2Infographic](https://text2infographic.com/) - AI infographic generator and editor.
 - [Seede.ai](https://seede.ai/) - Create a stunning poster in just 1 minute with Seede.
 - [Magic Patterns](https://www.magicpatterns.com/) - AI-based UI builder with Figma export and React code generation.
+- [AnySlide](https://anyslide.app) - AI slide deck generator with HTML and image-rendered engines, supporting native Chinese, Japanese, and Korean text.
 
 
 ### Image libraries


### PR DESCRIPTION
Hi @mahseema! Adding **AnySlide** to the `### Graphic design` section, alongside Gamma and the other slide-adjacent tools.

### What it is
An AI slide deck generator that turns articles, links, or PDFs into a full presentation in ~30 seconds. Two rendering engines:
- **HTML path** — outputs inline-editable web slides (reveal.js / Slidev style)
- **gpt-image-2 path** — renders each page as a full image with **native Chinese / Japanese / Korean text**, solving the garbled-CJK problem most AI image tools have with non-Latin scripts

### Why it fits this section
The Graphic design section already includes Gamma (presentations), Text2Infographic, Seede.ai, and Magic Patterns. AnySlide adds:
- A specific CJK-rendering capability that none of the existing entries have
- A second engine (gpt-image-2 full-image rendering) on top of the HTML approach used by Gamma

### Live
- Public: https://anyslide.app
- No waitlist, 60 free credits at signup, no credit card

### Disclosure
I'm the maker of AnySlide. Thanks for maintaining the list!