### PR TITLE
Add AutomaDocs to Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [AutomaDocs](https://automadocs.com) - AI documentation platform for GitHub repos. Tree-sitter AST chunking, Claude generation, hybrid retrieval (BM25 + Pinecone vector). Webhook-driven regeneration on every push.
 
 
 ## Image


### PR DESCRIPTION
Hi maintainers,

Adding [AutomaDocs](https://automadocs.com), an AI documentation platform for GitHub repositories.

**What it does:** Parses code with Tree-sitter (AST-aware chunking), generates docs with Claude, hybrid retrieval over chunks (BM25 + Pinecone vector + RRF) with inline file:line citations.

**Differentiator from Stenography / Mintlify already in the list:** webhook-driven selective regeneration on every git push (only re-processes changed chunks), so docs stay in sync with the code without a manual rebuild step.

**Free to try:** 1 public repo + 10 generations/month, no credit card.

**Live examples (real OSS projects):**
- https://automadocs.com/docs/hyperium/tonic
- https://automadocs.com/docs/kubeshark/kubeshark
- https://automadocs.com/docs/crossplane/crossplane

Added the entry at the end of the **Code** section since the list is chronological in that section. Happy to move, reword, or close if it is not a fit.

Thanks for maintaining this list.

— Liz