### PR TITLE
Add Dakera — self-hosted MCP-native agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted MCP-native agent memory server. Gives AI agents persistent, decay-weighted memory via 83 MCP tools — no cloud, full data control. RocksDB + HNSW backend, 87.8% LoCoMo benchmark. Works with Claude Code, Cursor, and any MCP-compatible agent. [#opensource](https://github.com/dakera-ai/dakera-mcp)
 
 
 ## Code


### PR DESCRIPTION
## Add Dakera to Developer tools

**[Dakera](https://github.com/dakera-ai/dakera-mcp)** is an open-source self-hosted MCP-native agent memory server — infrastructure for AI developers who need their agents to have persistent, long-term memory.

### Why it belongs in Developer tools
Developers building AI agents with Claude Code, Cursor, or any MCP-compatible client can plug Dakera in directly to give their agents durable memory across sessions — no cloud, no external API keys, full control.

### Key details
- **83 MCP tools** — store, recall, session management, namespace isolation, decay config
- **Decay-weighted vector recall** — memories fade naturally by importance, preventing stale context
- **87.8% LoCoMo benchmark** — standardized long-term conversational memory eval
- **RocksDB + HNSW** backend (Rust)
- **Docker Compose deployment** — MinIO + Prometheus included
- **Multi-SDK**: Python, JavaScript, Rust, Go
- **Apache-2.0**, fully open-source