### PR TITLE
readme: remove Emilio (product no longer working since 2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Cosmos](https://meetcosmos.com/) - Use AI locally and offline to search your media files by their content, find similar images or video scenes using reference images, and transcribe video.
 - [aiPDF](https://aipdf.ai) - The most advanced AI document assistant
 - [Summary With AI](https://www.summarywithai.com/) - Summarize any long PDF with AI. Comprehensive summaries using information from all pages of a document.
-- [Emilio](https://getemil.io?ref=mahseema-awesome-ai-tools) - Stop drowning in emails - Emilio prioritizes and automates your email, saving 60% of your time
 - [Pieces](https://pieces.app/) - AI-enabled productivity tool designed to supercharge developer efficiency,with an on-device copilot that helps capture, enrich, and reuse useful materials, streamline collaboration, and solve complex problems through a contextual understanding of dev workflow
 - [Huntr AI Resume Builder](https://huntr.co/product/ai-resume-builder/?ref=mahseema-awesome-ai-tools) - Craft the perfect resume, with a little help from AI. Huntr’s customizable AI Resume Builder will help you craft a well-written, ATS-friendly resume to help you land more interviews.
 - [Chat With PDF by Copilot.us](https://copilot.us/apps/chat-with-pdf) - An AI app that enables dialogue with PDF documents, supporting interactions with multiple files simultaneously through language models.


### PR DESCRIPTION
<!--
  Draft filled for Emilio removal PR — copy into GitHub, then restore:
  git checkout -- .github/PULL_REQUEST_TEMPLATE.md
-->

## 📝 New Tool Information
<!-- N/A — this PR removes a listing; section kept for template compatibility. -->
- **Tool Name:** *(removal — not applicable)*
- **Description:** *(removal — not applicable)*
- **Tool URL:** *(removed entry was getemil.io)*
- **Altern.ai page link:** *(if available)* *(N/A)*


## 📌 Description
Removes **Emilio** from the **Productivity** section of `README.md`. The product **no longer works** (defunct **since 2024**), so the link and listing are misleading for readers of this curated list.

**Removed line:**
`- [Emilio](https://getemil.io?ref=mahseema-awesome-ai-tools) - Stop drowning in emails - Emilio prioritizes and automates your email, saving 60% of your time`

---

## ✅ Checklist
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md) *(Note: `CONTRIBUTING.md` is not present at the repo root in this checkout.)*
- [x] **Only one tool is modified in this PR** *(single removal)*
- [ ] All required fields (name, description, URL, altern.ai link if available) are provided *(N/A — removal PR, not a new tool submission)*
- [ ] The tool link is **valid** and accessible *(N/A — listing removed because the service is not operational)*
- [ ] The tool is **not already listed** *(N/A — removal)*
- [ ] The tool is placed in the **correct category** *(N/A — removal)*
- [ ] **The tool is added at the *end* of its category** *(N/A — removal)*
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [ ] 📚 Documentation / README update
- [ ] ➕ Adding a new AI tool
- [x] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix
- [ ] Other (please specify):

---

## 📷 Screenshots / Demo (if applicable)
Not applicable — README-only removal.

---

## 💡 Additional Notes
Commit on branch `remove-emilio-defunct-service`: **readme: remove Emilio (product no longer working since 2024)**. Maintainer can verify e.g. site/API shutdown or redirects before merge if desired.
