### PR TITLE
Add gptimage2.plus to Image → Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI Photo Forge](https://aiphotoforge.com/) - A Telegram bot to generate AI pictures of you.
 - [AI Boost](https://boost.pictures/) - All-in-one service for creating and editing images with AI: upscale images, swap faces, generate new visuals and avatars, try on outfits, reshape body contours, change backgrounds, retouch faces, and even test out tattoos.
 - [PlantTattoosAI](https://www.planttattoosai.com/) - Plant and flower tattoos designs generator trained on real botanicals.
+- [gptimage2.plus](https://gptimage2.plus/) - A GPT-Image-2 web app for text-to-image, mask-based inpainting, AI headshots, and photo restoration at up to 2K with no watermark.
 
 
 


### PR DESCRIPTION
Adds gptimage2.plus, a GPT-Image-2 web app, to the **Image → Services** section per existing format.

- Added at the end of the section.
- Live and actively maintained.
- Free signup tier (5 credits, no card).
- Available in 12 languages.

Thanks!