### PR TITLE
Add Dakera: self-hosted MCP agent memory server to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Developer tools
 
+- [Dakera](https://github.com/Dakera-AI/dakera) - Self-hosted agent memory server with hybrid BM25 + HNSW vector retrieval, decay-weighted recall, and multi-agent namespacing. MCP-native integration for Claude Code, Cursor, and Windsurf. SDKs for Python, TypeScript, Go, and Rust. [#opensource](https://github.com/Dakera-AI/dakera)
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/Dakera-AI/dakera) to the **Developer tools** section.

Dakera is an open-source, self-hosted agent memory server for LLM developers:
- Hybrid BM25 + HNSW vector retrieval for high-recall semantic search
- Decay-weighted recall — memories fade with time, like human memory
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration with Claude Code, Cursor, and Windsurf
- SDKs for Python, TypeScript, Go, and Rust

It fills a gap in this list for persistent agent memory infrastructure — the "long-term memory" layer for LLM-powered developer tools.
