### PR TITLE
Add Certvo to Developer tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Certvo](https://certvo.com) - AI-powered WCAG accessibility scanner that generates production-ready code fixes (HTML/CSS/JS) using Claude AI. Includes VPAT 2.4 generation and an MCP server for Claude Code and Cursor. Free tier available.
 
 
 ## Code


### PR DESCRIPTION
Hi! Submitting Certvo for the Developer tools section.

Certvo is an AI-powered web accessibility scanner that goes beyond issue reporting — it generates production-ready WCAG code fixes using Claude AI. It also exposes a Model Context Protocol (MCP) server so AI agents like Claude Code and Cursor can scan and fix accessibility issues directly.

Key features:
- WCAG 2.1 A/AA/AAA rule coverage via Playwright + axe-core
- AI-generated code fixes (not just issue reports)
- VPAT 2.4 / Section 508 report generation
- MCP server: `claude mcp add --transport http certvo https://certvo.com/api/mcp/`
- Free tier: anonymous scans + 10 AI fixes/month

https://certvo.com

Happy to revise the bullet description or move to a different section if you'd prefer.