### PR TITLE
Add Dakera: self-hosted MCP agent memory server to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Developer tools
 
+- [Dakera](https://github.com/dakera-ai/dakera-deploy) - Self-hosted agent memory server with hybrid BM25 + HNSW vector retrieval, decay-weighted recall, and multi-agent namespacing. MCP-native integration for Claude Code, Cursor, and Windsurf.
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/dakera-ai/dakera-deploy) — a production-ready, self-hosted agent memory server.

**Key features:**
- Hybrid BM25 + HNSW vector retrieval for high-recall semantic search
- Decay-weighted recall (importance fades over time, like human memory)
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration — works with Claude Code, Cursor, Windsurf, and any MCP client
- SDKs for Python, TypeScript, Go, and Rust

Open-source (Apache 2.0), self-hosted, production-ready.
