### PR TITLE
Add EuroForge AI Cost Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- [EuroForge AI Cost Calculator](https://euroforge-autopilot.vercel.app/chatgpt-team-cost-calculator/) - Estimate wasted ChatGPT Team seats, duplicate AI subscriptions, and LLM API spend from one AI cost worksheet.
 
 
 ### Meeting assistants


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** EuroForge AI Cost Calculator
- **Description:** Estimate wasted ChatGPT Team seats, duplicate AI subscriptions, and LLM API spend from one AI cost worksheet.
- **Tool URL:** https://euroforge-autopilot.vercel.app/chatgpt-team-cost-calculator/
- **Altern.ai page link:** N/A

## Description
Added EuroForge AI Cost Calculator to the end of the Productivity category.

## Checklist
- [x] I checked the available repository contribution notes in README.md and the PR template; CONTRIBUTING.md is referenced but not present in this checkout
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

## Type of Change
- [x] Documentation / README update
- [x] Adding a new AI tool

## Screenshots / Demo
Live URL check: `curl -I https://euroforge-autopilot.vercel.app/chatgpt-team-cost-calculator/` returns HTTP 200.

## Additional Notes
This PR adds a single buyer-intent AI spend calculator link and does not touch any other entries.