### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local, open-source macOS app for listening to Claude Code and Codex agents as they work, with Global Mix and blocker alerts.
 
 
 ## Image


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** Agent FM
- **Description:** Local, open-source macOS app for listening to Claude Code and Codex agents as they work.
- **Tool URL:** https://github.com/agentfm-ai/agent-fm
- **Altern.ai page link:** N/A

## 📌 Description
Added Agent FM to the Code section because it is a developer-focused companion for monitoring Claude Code and Codex sessions, with Global Mix and blocker alerts.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [ ] 📚 Documentation / README update
- [x] ➕ Adding a new AI tool
- [ ] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix
- [ ] Other (please specify):

---

## 📷 Screenshots / Demo (if applicable)
N/A

---

## 💡 Additional Notes
N/A
