### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Marketing AI Tools
 
+- [WebCoreLab](https://webcorelab.com) — AI-powered SEO audit (272 checks) + GEO/AEO optimization. Tracks AI citation rate in ChatGPT, Claude, Perplexity, Google AI Overviews. Toronto agency.
 *You can also find  more comprehensive list on *[Marketing List](https://github.com/mahseema/awesome-ai-tools/blob/main/marketing.md)*
 
 - **[Jasper AI](https://www.jasper.ai/)** - AI-powered tool for generating marketing content like blogs, emails, and ad copy.


### PR DESCRIPTION
Hi! Adding WebCoreLab to the SEO & Marketing section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
