### PR TITLE
Add JS2Mail — form backend for AI-generated static sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [CodeRabbit](https://coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
+- - [JS2Mail](https://js2mail.dev) - Form backend for AI-generated static sites. Add a contact form to any HTML page with one action URL — submissions route to your own connected mailbox (Gmail, Outlook, SMTP). No backend or signup required.
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
 - [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
 - [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.


### PR DESCRIPTION
Adds JS2Mail to Developer Tools. It lets developers add contact forms to static HTML pages with a single action URL, routing submissions to their own mailbox.

## 📝 New Tool Information
<!-- Fill this section when adding a new tool -->
- **Tool Name:**  
- **Description:** (max 1 sentence)  
- **Tool URL:**  
- **Altern.ai page link:** (if available)  


## 📌 Description
<!-- Please include a summary of the changes and the related issue (if any). -->
<!-- Example: Added a new AI tool to the "Text-to-Image" section. -->

---

## ✅ Checklist
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] **Only one tool is modified in this PR**
- [ ] All required fields (name, description, URL, altern.ai link if available) are provided
- [ ] The tool link is **valid** and accessible
- [ ] The tool is **not already listed**
- [ ] The tool is placed in the **correct category**
- [ ] **The tool is added at the *end* of its category**
- [ ] No unrelated changes included in this PR

---


## 🛠 Type of Change
<!-- Please check all options that apply. -->
- [ ] 📚 Documentation / README update
- [ ] ➕ Adding a new AI tool
- [ ] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix
- [ ] Other (please specify):

---


## 📷 Screenshots / Demo (if applicable)
<!-- Add screenshots or links that help explain the change. -->

---

## 💡 Additional Notes
<!-- Any additional information, context, or tips for reviewers. -->
