### PR TITLE
Add XFMS — hosted MCP for LLM model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
 - [Wordware](https://www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
 - [CodeRabbit](https://coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
+- [XFMS](https://github.com/VisionAIrySE/XFMS) - Pick the right LLM for any stated task. Aggregates evidence from 8 independent benchmark sources and returns a ranked shortlist with plain-English rationale per pick. [#opensource](https://github.com/VisionAIrySE/XFMS)
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
 - [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.


### PR DESCRIPTION
Adds [XFMS](https://github.com/VisionAIrySE/XFMS) to the Developer tools section.

XFMS is a hosted MCP server that picks the right LLM for any stated task. It aggregates evidence from 8 independent third-party benchmark sources (no provider self-reports), infers which quality dimensions matter from the stated purpose, and returns a ranked shortlist with plain-English rationale per pick.

Install in one line: `claude mcp add xfms --transport http https://xfms.vercel.app/mcp/`

Part of the [Xpansion Framework](https://xpansion.dev).