### PR TITLE
Add TeamOffsite to Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Daruy](https://daruy.space/) - Personalized Gift Idea Generator
 - [Promptly](https://searchpromptly.com/) - Discover, create and share powerful prompts
 - [Melies](https://melies.co) - AI Filmmaking software
+- [TeamOffsite](https://teamoffsite.ai) - Build and operate agent teams without code, from [mercury.build](https://mercury.build). Bring your own agents such as Cursor, Claude Code, Devin, and OpenClaw, and manage orchestration and governance from a single place.
 
 
 ## Learning resources


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** TeamOffsite
- **Description:** No-code platform to build and orchestrate teams of AI agents with bring-your-own-agent support for Cursor, Claude Code, Devin, and OpenClaw.
- **Tool URL:** https://teamoffsite.ai
- **Altern.ai page link:** N/A

## 📌 Description
Added TeamOffsite — a no-code AI agent orchestration platform — to the **Other** section.

## ✅ Checklist
- [x] I have read the Contribution Guidelines
- [x] **Only one tool is modified in this PR**
- [x] All required fields are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool

## 💡 Additional Notes
Disclosure: I am affiliated with TeamOffsite (mercury.build) — submitting our own product. Happy to adjust wording or placement.