### PR TITLE
Add GPT for Sheets to productivity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Elephas](https://elephas.app/?ref=mahseema-awesome-ai-tools) - Personal AI writing assistant for the Mac.
 - [Lemmy](https://lemmy.co/?ref=mahseema-awesome-ai-tools) - Autonomous AI Assistant for Work.
 - [Google Sheets Formula Generator](https://bettersheets.co/google-sheets-formula-generator?ref=mahseema-awesome-ai-tools) - Forget about frustrating formulas in Google Sheets.
+- [GPT for Sheets](https://docgpt.ai/gpt-for-sheets) - AI assistant for Google Sheets to generate formulas, enrich rows, classify data, translate text, and automate spreadsheet workflows.
 - [CreateEasily](https://createeasily.com/?ref=mahseema-awesome-ai-tools) - Free speech-to-text tool for content creators that accurately transcribes audio & video files up to 2GB.
 - [Cosmos](https://meetcosmos.com/) - Use AI locally and offline to search your media files by their content, find similar images or video scenes using reference images, and transcribe video.
 - [aiPDF](https://aipdf.ai) - The most advanced AI document assistant


### PR DESCRIPTION
Adds GPT for Sheets to the productivity section as a Google Sheets-focused AI workflow tool.\n\nWhy it fits:\n- relevant to the productivity category\n- complements the existing Sheets formula tools already listed\n- description is short, factual, and consistent with the list style