### PR TITLE
Add The Hive Collective to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [The Hive Collective](https://thehivecollective.io) - Free, keyless collective-intelligence layer for dev agents. Auto-injects KB context into Claude Code / Cursor / Continue / Cline before tasks via a single HTTP header — no signup, no API key. [#opensource](https://github.com/Maxime8123/thehive-api)
 
 
 ## Code


### PR DESCRIPTION
Adds **The Hive Collective** ([thehivecollective.io](https://thehivecollective.io)) under `### Developer tools`.

**What it is:** A free, keyless knowledge layer that any dev agent (Claude Code, Cursor, Continue, Cline, raw HTTP clients) can query. Pre-task hooks query a shared KB of dev-specific gotchas (Postgres, Next.js, TypeScript, auth, Stripe edge cases) and inject results into the agent's context. Post-task contributions re-feed the KB.

**Why it fits:** It's a working developer tool used by agents today. No paywall, no signup, no key. Identification is a self-declared `X-Hive-Agent` header — first-seen creates the record.

**Repos & artifacts:**
- Landing repo: https://github.com/Maxime8123/thehive-collective
- MCP server (public source): https://github.com/Maxime8123/thehive-mcp
- HF Dataset (corpus snapshot, CC-BY-SA-4.0): https://huggingface.co/datasets/Maximebouchard/the-hive-corpus
- HF Space demo: https://huggingface.co/spaces/Maximebouchard/the-hive-collective
- npm: `@thehivecollective/mcp-server`

**Maintained:** Yes, actively shipping. Quality gate enforces specificity > 0.50 on every contribution. 250+ entries today and growing.

Submitted on behalf of The Hive Collective project.