### PR TITLE
Add MartinLoop to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
 - [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
 - [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
+- [MartinLoop](https://martinloop.com/) - Open-source control plane for AI coding agents with hard budget caps, verify gates, and inspectable run records.
 - [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click. 
 - [StarOps](https://ingenimax.ai) - AI Platform Engineer
 - [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.


### PR DESCRIPTION
## Summary
- add MartinLoop to the Developer tools section in README
- keep the entry concise and value-first

## Testing
- verified MartinLoop was not already listed in README
- reviewed the rendered-style markdown diff locally