### PR TITLE
Add Tinyposter

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[Tinyposter](https://tinyposter.app)** - Post to 11 social platforms (Instagram, X, Threads, TikTok, LinkedIn, YouTube, Facebook, Pinterest, Bluesky, Mastodon, Reddit) from one place. MCP, CLI, OpenAPI. 3-day free trial.
 
 
 ### Phone Calls


### PR DESCRIPTION
Adds Tinyposter to the Marketing AI Tools section.

Tinyposter is a social posting tool that publishes to 11 platforms (Instagram, X, Threads, TikTok, LinkedIn, YouTube, Facebook, Pinterest, Bluesky, Mastodon, Reddit) from one place. Works as an MCP server, CLI, or via OpenAPI.

- 3-day free trial
- Home: https://tinyposter.app
- MCP docs: https://tinyposter.app/docs/mcp