### PR TITLE
Add DocWorm to Academia section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Explainpaper](https://www.explainpaper.com/) - A better way to read academic papers. Upload a paper, highlight confusing text, get an explanation.
 - [Galactica](https://galactica.org/) - A large language model for science. Can summarize academic literature, solve math problems, generate Wiki articles, write scientific code, annotate molecules and proteins, and more. [Model API](https://github.com/paperswithcode/galai).
 - [Consensus](https://consensus.app/search/) - Consensus is a search engine that uses AI to find answers in scientific research.
+- [DocWorm](https://docworm.app/) - Learn from PDFs with page-aware Q&A, chapter-by-chapter slide generation, voice agent and a 21k-title open-access library.
 - [Sourcely](https://www.sourcely.net/) - Academic Citation Finding Tool with AI
 - [SciSpace](https://scispace.com/) - AI Chat for scientific PDFs.
 - [NotebookLM](https://notebooklm.google.com/) - AI Chat on your own document, link and text resources.


### PR DESCRIPTION
PDF learning app with chapter-structured slides, voice agent and an open-access content library. Closest comparator: NotebookLM (already listed).

## 📝 New Tool Information
- **Tool Name:** DocWorm
- **Description:** PDF learning app with page-aware Q&A, chapter-structured slide generation, voice agent and a 21k-title open-access library.
- **Tool URL:** https://play.google.com/store/apps/details?id=com.profbookworm.app
- **Altern.ai page link:** (not yet available, account-age restricted until May 28, 2026)


## 📌 Description
Added DocWorm to the Academia section. PDF-centric learning app with chapter-structured presentation generation, voice agent and an open-access content library. Closest peers already listed in this section: NotebookLM and SciSpace.

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---


## 🛠 Type of Change
- [x] ➕ Adding a new AI tool

---


## 📷 Screenshots / Demo (if applicable)
https://play.google.com/store/apps/details?id=com.profbookworm.app


## 💡 Additional Notes
DocWorm is Android-first (Play Store), web version planned later this year. The catalogue (21k entries) is open-access licensed (CC-BY / public domain). Differentiator vs NotebookLM: chapter-structured slides with TTS instead of flat audio summary.
