### PR TITLE
Add AI Models Catalog — structured YAML catalog of 4,587+ AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 > *More complete list of AI Models: [Awesome AI Models](https://github.com/dariubs/awesome-ai-models)*
 
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured YAML catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Interactive catalog with comparison, cost calculator, and model picker.
+
 - [OpenAI API](https://openai.com/api/) - OpenAI's API provides access to GPT-3 and GPT-4 models, which performs a wide variety of natural language tasks, and Codex, which translates natural language to code.
 - [Gopher](https://www.deepmind.com/blog/language-modelling-at-scale-gopher-ethical-considerations-and-retrieval) - Gopher by DeepMind is a 280 billion parameter language model.
 - [OPT](https://huggingface.co/facebook/opt-350m) - Open Pretrained Transformers (OPT) by Facebook is a suite of decoder-only pre-trained transformers. [Announcement](https://ai.facebook.com/blog/democratizing-access-to-large-scale-language-models-with-opt-175b/). [OPT-175B text generation](https://opt.alpa.ai/) hosted by Alpa.

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 - [Altern](https://altern.ai) - Find Best AI Tools
 - [AI For Developers](https://aifordevelopers.org) - List of AI DevTools
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured database of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities
 - [Best of AI](https://github.com/best-of-ai/best-of-ai) - Like Michelin Guide for AI
 - [Awesome AI Models](https://github.com/dariubs/awesome-ai-models) - A curated list of top AI models and LLMs
 - [Awesome AI Coding Tools](https://github.com/ai-for-developers/awesome-ai-coding-tools) - Curated list of AI-powered developer tools.


### PR DESCRIPTION
## Addition

**AI Models Catalog** — https://github.com/i-need-token/ai-models

A structured YAML catalog of 4,587+ AI models across 95 providers with first-party data including pricing, context windows, modalities, and capabilities.

### Why this is useful for awesome-ai-tools readers:
- **Interactive catalog** with search, filter, compare, cost calculator, and model picker: https://i-need-token.github.io/ai-models/
- **Free to use** — all data is MIT-licensed, available as JSON/CSV/npm package
- **First-party data only** — pricing and capabilities verified from provider APIs
- **81 free models**, 2,350 with tool calling, 1,306 with reasoning, 527 open weights
- **Programmable** — TypeScript types + Zod validation, npm package, GitHub Action

### Placement
Added to the **Models** section, right after the existing 'More complete list' note, as a comprehensive model catalog resource.

### Checklist
- [x] The entry has a description
- [x] The entry is in the appropriate section
- [x] The entry follows the existing format