### PR TITLE
Add LLM Reference to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [LLM Reference](https://www.llmreference.com/) - A free directory comparing 1,700+ LLM models across 130+ providers with benchmark scores, pricing, and context windows to help developers pick the right model.
 
 
 ## Code


### PR DESCRIPTION
Adds [LLM Reference](https://www.llmreference.com/) to the **AI Text → Developer tools** subsection.

LLM Reference is a free directory comparing 1,700+ LLM models across 130+ providers with benchmark scores, pricing, and context windows. It helps developers pick the right model for a use case in seconds.

**Disclosure:** I'm affiliated with the site. Happy to revise wording or move to a different section if you prefer.