### PR TITLE
Add TinyTools to Developer tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
 
 
+- [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based AI developer utilities: AI cost calculator for comparing LLM API pricing, AI robots.txt generator, SEO meta tag generator, OG image generator, and more. All run in-browser, no signup required. #opensource
 ## Code
 
 - [GitHub Copilot](https://github.com/features/copilot) - GitHub Copilot uses the OpenAI Codex to suggest code and entire functions in real-time, right from your editor.


### PR DESCRIPTION
## Description

Adds [TinyTools](https://tinytools-smoky.vercel.app/) to the Developer tools section.

**TinyTools** is a collection of free, single-purpose web utilities that run entirely in the browser — no signup, no data sent to servers. Particularly useful for developers:

- **AI cost calculator** – compare LLM API pricing across OpenAI, Anthropic, Gemini, and more
- **AI robots.txt generator** – generate robots.txt with AI crawler rules
- **SEO meta tag generator** – generate Open Graph and meta tags
- **OG image generator** – create social preview images
- **AI background remover** – removes backgrounds on-device (no upload)
- **Favicon generator**, **color palette generator**, and more

Open source: https://github.com/alfredoautomatizaloconia-cloud/tinytools

Fits the Developer tools section alongside tools like OpenAI Downtime Monitor.