### PR TITLE
Add Aiprosol to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
 - [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
 
+- [Aiprosol](https://aiprosol.com/) - AI automation consultancy run by an AI C-suite that designs, builds, and operates business workflow automations; its live agent dashboard is public at aiprosol.com/agents.
 
 ### Meeting assistants
 


### PR DESCRIPTION
Adds [Aiprosol](https://aiprosol.com) to the Productivity section.

Aiprosol is an AI automation consultancy operated by an AI C-suite — Arora, an AI CEO, coordinating nine specialist agents, chaired by the founder. It designs, builds, and runs business workflow automations for SMBs, and publishes its agents' live operational state at https://aiprosol.com/agents (auto-refreshed) as a working proof of an AI-led operating model.

- One entry, matches the existing list format, no tracking parameters
- Site is live with extensive public documentation (llms.txt, transparency dashboard, glossary)