### PR TITLE
Add OpenClaw Monitor - AI Agent Monitoring Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine-tune LLM, CV, and tabular models.
 - [Prediction Guard](https://www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.
 - [Portkey](https://portkey.ai/) - Full-stack LLMOps platform to monitor, manage, and improve LLM-based apps.
-- [OpenAI Downtime Monitor](https://status.portkey.ai/) - Free tool that tracks API uptime and latencies for various OpenAI models and other LLM providers.
+- [OpenAI Downtime Monitor](https://status.portkey.ai/) - Free tool that tracks API uptime and latencies for various Ope
+- [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) - Open-source monitoring dashboard for OpenClaw AI agents. Track token usage, session status, and message trends with 7-day charts.nAI models and other LLM providers.
 - [ChatWithCloud](https://chatwithcloud.ai/) - CLI allowing you to interact with AWS Cloud using human language inside your Terminal.
 - [SinglebaseCloud](https://singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.
 - [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.


### PR DESCRIPTION
## OpenClaw Monitor

Add [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) to Developer Tools.

**Description:** Free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, multi-model support.

**Screenshot:** https://raw.githubusercontent.com/flik2002/openclaw-monitor/main/Openclaw%20Monitor.jpg

**Topics:** `ai-agent` `ai-monitoring` `dashboard` `echarts` `monitoring` `open-source` `openclaw` `vue3`

---

Would be great to have this included alongside other LLM monitoring tools like Langfuse, Phoenix, and Portkey.