### PR TITLE
Add CreatorSkills to Writing assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [DeepL Write](https://www.deepl.com/write) - AI writing tool that improves written communication.
 - [Headlinesai.pro](https://www.headlinesai.pro/) - This AI powered tool can help you in generating catchy and optimized headlines based on your content for multiple platforms like Youtube, Medium, Indie Hackers and Reddit.
 - [GPTLocalhost](https://gptlocalhost.com/demo/) - A local Word Add-in for you to use local LLM servers in Microsoft Word. Alternative to "Copilot in Word" and completely local.
+- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 
 
 ### ChatGPT extensions


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **Writing assistants** section.

CreatorSkills is a marketplace of 30+ downloadable AI skill packs for content creators covering YouTube scripting, sponsorship analysis, audience growth, and more. Skills are compatible with Claude and ChatGPT.

## Why this fits

- External hosted web tool (not a GitHub repo)
- Directly assists content creators with writing workflows (scripts, outreach, hooks)
- Works with both Claude and ChatGPT