### PR TITLE
Add Craqly to Meeting assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Sybill](https://www.sybill.ai/) - Sybill generates summaries of sales calls, including next steps, pain points and areas of interest, by combining transcript and emotion-based insights.
 - [Loopin AI](https://www.loopinhq.com/) - Loopin is a collaborative meeting workspace that not only enables you to record, transcribe & summaries meetings using AI, but also enables you to auto-organise meeting notes on top of your calendar.
 - [Scribbl](https://www.scribbl.co) - AI Meeting Notes
+- [Craqly](https://craqly.com) - Real-time AI work assistant for meetings, interviews, and sales calls that surfaces live, context-aware suggestions on a stealth overlay invisible to screen-share, with no bot joining the call.
 
 ### Academia
 


### PR DESCRIPTION
Adds Craqly to the Meeting assistants section.

Tool Name: Craqly
Tool URL: https://craqly.com
Description: Real-time AI work assistant for meetings, interviews, and sales calls that surfaces live, context-aware suggestions on a stealth overlay invisible to screen-share, with no bot joining the call.

Only one tool added in this PR. The link is valid and accessible, the tool is not already listed, and the entry follows the existing one-sentence format and section placement.