### PR TITLE
Add GEO/AEO Tracker to Marketing AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[GEO/AEO Tracker](https://organikpi.com/tools/geo-aeo-tracker/)** - Open-source, local-first dashboard that tracks your brand's visibility across 6 AI models (ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, Grok) with a 0-100 visibility score, citation tracking and competitor battlecards. Bring your own API keys, MIT licensed.
 
 
 ### Phone Calls


### PR DESCRIPTION
Adding **GEO/AEO Tracker** under *Marketing AI Tools*.

A free, open-source, local-first dashboard that tracks brand visibility across 6 AI models (ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, Grok), giving a single 0-100 visibility score plus citation tracking and competitor battlecards. Bring-your-own-API-keys, MIT licensed.

- Fits the Marketing AI Tools section (AI search visibility / GEO is a marketing discipline).
- Single addition, matches existing `**[Name](url)** - desc` format.
- Not a duplicate.