### PR TITLE
Add Hermes to Phone Calls section

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI Voice Agents](https://diallink.com/) — AI Voice Agents for business calls and routine tasks, powered by DialLink cloud phone system.
 - [Cald.ai](https://cald.ai) - AI based calling agents for outbound and inbound phone calls.
 - [Rosie](https://heyrosie.com/) - AI Phone Answering Service
+- [Hermes](https://buildwithhermes.com) - White-label operating platform for AI voice agencies. Deploy inbound and outbound voice agents under your own brand with built-in CRM, campaign orchestration, telephony, and usage-based billing. From $149/month.
 
 ### Speech
 - [Eleven Labs](https://beta.elevenlabs.io/) - AI voice generator.


### PR DESCRIPTION
Adding Hermes to the Audio > Phone Calls section, alongside AICaller, DialLink, Cald.ai, and Rosie.

The existing entries are mostly single-agent calling tools. Hermes fills a different slot: it is the operating layer agencies use to run those agents at scale under their own brand. It bundles the voice agents with a native CRM, campaign orchestration for inbound and outbound, telephony, and usage-based billing, so an agency can manage multiple client workspaces from one platform instead of stitching several tools together.

Entry details:
- Name: Hermes
- URL: https://buildwithhermes.com
- Category fit: Audio > Phone Calls (AI calling agents)
- Pricing: from $149/month

Happy to reword or move the entry if you prefer a different spot or format.