### PR TITLE
Add NotFair (open-source Claude Code skills for SEO & paid ads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
 - **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
 - **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- **[NotFair](https://github.com/nowork-studio/NotFair)** - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 
 
 ### Phone Calls


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** NotFair
- **Description:** Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
- **Tool URL:** https://github.com/nowork-studio/NotFair
- **Altern.ai page link:** N/A

## 📌 Description

Hi — thanks for maintaining this list! I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source (MIT) set of Claude Code skills for marketing work. It has ~2.9k stars on GitHub.

NotFair covers three areas: SEO/GEO (keyword research, meta tags, schema markup, content writing, geo optimization), Google Ads (audits, wasted-spend detection, keyword and bid management), and Meta Ads (ROAS analysis, creative fatigue, audience overlap). What makes it different from the existing marketing tools on the list is that it plugs directly into live ad and analytics data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so it can read your actual account data and take approved actions, not just generate copy.

I've placed it at the end of the Marketing AI Tools section to follow the contribution guidelines. Happy to reword, move, or trim the description if you'd prefer a different format.

## ✅ Checklist
- [x] I have read the Contribution Guidelines
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool