### PR TITLE
Add CoPilot Interview to Other AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ## Other
 
+- [CoPilot Interview](https://copilotinterview.com) - Real-time AI assistant for live job interviews — structured help on coding, system design, and behavioral questions over Zoom/Teams/Meet; native desktop app with a free tier.
 - [Taranify](https://www.taranify.com) - Using AI, Taranify finds you Spotify playlists, Netflix shows, Books & Foods you'd enjoy when you don't exactly know what you want. 
 - [Diagram](https://diagram.com/) - Magical new ways to design products.
 - [PromptBase](https://promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.


### PR DESCRIPTION
Adds **CoPilot Interview** ([copilotinterview.com](https://copilotinterview.com)) under the **Other** section.

It's a real-time AI assistant for live job interviews — structured help on coding, system design, and behavioral questions over Zoom/Teams/Meet, with a native desktop app and a free tier.

- Single-line addition that follows the existing `- [Name](url) - description.` format
- No other lines changed

Thanks for maintaining this list!