### PR TITLE
Add One Person Company

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ChatGPT prompt engineering for developers](https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/) - A short course by Isa Fulford (OpenAI) and Andrew Ng (DeepLearning.AI).
 - [OpenAI Cookbook](https://github.com/openai/openai-cookbook) - Examples and guides for using the OpenAI API.
 - [Robert Miles AI Safety](https://www.youtube.com/@RobertMilesAI) - Youtube channel about AI safety
+- [One Person Company](https://onepersoncompany.com) - 317 free skill guides, an SEO playbook, and AI tool comparisons for solo founders building a business with AI.
 
 ## Learn AI free
 ### Machine Learning


### PR DESCRIPTION
Adds **[One Person Company](https://onepersoncompany.com)** to the **Learning resources** section.

It's a free resource hub for solo founders and one-person businesses: **317 actionable skill guides**, a complete **SEO playbook**, and **AI tool comparisons** — all focused on growing a business without hiring a team.

It fits this list because it's a free learning library on applying AI tools to run a business.

Thanks for curating this list!