### PR TITLE
Add dehallucinator (LLM fact-checking) to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [dehallucinator](https://dehallucinator.apps.innovationbee.gr) - Fact-checking layer for LLM output that extracts every claim (numbers, dates, quotes, citations) and verifies each against the open web and structured sources (Wikidata, World Bank, Crossref), returning an evidence-backed, per-claim report with a trust grade.
 
 
 ## Code

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
-- [dehallucinator](https://dehallucinator.apps.innovationbee.gr) - Fact-checking layer for LLM output that extracts every claim (numbers, dates, quotes, citations) and verifies each against the open web and structured sources (Wikidata, World Bank, Crossref), returning an evidence-backed, per-claim report with a trust grade.
+- [dehallucinator](https://dehallucinator.io) - Fact-checking layer for LLM output that extracts every claim (numbers, dates, quotes, citations) and verifies each against the open web and structured sources (Wikidata, World Bank, Crossref), returning an evidence-backed, per-claim report with a trust grade.
 
 
 ## Code


### PR DESCRIPTION
**dehallucinator** is a fact-checking layer for LLM output. It extracts every checkable claim — numbers, dates, quotes, citations — and verifies each against the open web plus structured sources (Wikidata, World Bank, Crossref), returning an evidence-backed, per-claim report with a document trust grade. It is deliberately conservative: a claim is only refuted on positive contradiction from independent authoritative sources, so it abstains rather than wrongly accuses.

Placed under **Text → Developer tools**, next to Cleanlab (hallucination detection) as a closely related tool.

Live (free to try, no signup): https://dehallucinator.io