### PR TITLE
Add img2stl.art - AI Image to 3D STL Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI Photo Forge](https://aiphotoforge.com/) - A Telegram bot to generate AI pictures of you.
 - [AI Boost](https://boost.pictures/) - All-in-one service for creating and editing images with AI: upscale images, swap faces, generate new visuals and avatars, try on outfits, reshape body contours, change backgrounds, retouch faces, and even test out tattoos.
 - [PlantTattoosAI](https://www.planttattoosai.com/) - Plant and flower tattoos designs generator trained on real botanicals.
+- [img2stl.art](https://img2stl.art) - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds in STL format.
 
 
 


### PR DESCRIPTION
This PR adds [img2stl.art](https://img2stl.art) to the awesome-ai-tools list under the **Image > Services** section.

**img2stl.art** is an AI-powered tool that converts photos to 3D printable STL files. Users simply upload a photo and receive a ready-to-print STL file in seconds — no 3D expertise required.

This is a great fit for the Image section as it transforms 2D images into 3D printable models using AI.