### PR TITLE
Add Hermes to Phone Calls section

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI Voice Agents](https://diallink.com/) — AI Voice Agents for business calls and routine tasks, powered by DialLink cloud phone system.
 - [Cald.ai](https://cald.ai) - AI based calling agents for outbound and inbound phone calls.
 - [Rosie](https://heyrosie.com/) - AI Phone Answering Service
+- [Hermes](https://www.buildwithhermes.com/) - Operating platform for AI voice agencies to deploy, manage, and bill white-label voice agents for inbound and outbound calls, with built-in CRM and campaign orchestration. From $149/month.
 
 ### Speech
 - [Eleven Labs](https://beta.elevenlabs.io/) - AI voice generator.


### PR DESCRIPTION
Adds Hermes under Phone Calls.

Hermes is the operating platform AI voice agencies use to deploy, manage, and bill white-label AI voice agents for inbound and outbound calls, with native CRM and campaign orchestration in one place. It fits alongside the other AI calling platforms in this section. Pricing from $149/month. https://www.buildwithhermes.com/