### PR TITLE
Add Callbook to AI tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Inline Help](https://inlinehelp.com) - Answer customer questions before they ask
 - [Aidbase](https://www.aidbase.ai) - AI-Powered Support for your SaaS startup.
 - [Twig](https://www.twig.so/) - Twig is an AI assistant that resolves customer issues instantly, supporting both users and support agents 24/7.
+- [Callbook](https://getcallbook.com) - AI phone receptionist that answers calls 24/7 and books the job for plumbers, HVAC, electricians & other home-service businesses.
 
 
 ### Other text generators


### PR DESCRIPTION
## 📝 New Tool Information

**Tool Name:** Callbook
**Description:** AI phone receptionist that answers calls 24/7 and books the job for home-service businesses.
**Tool URL:** https://getcallbook.com

## 📌 Description

Adds **Callbook** to the **Customer Support** section. It's an AI phone-answering / virtual receptionist for service businesses (plumbers, HVAC, electricians, etc.) — it answers calls 24/7, qualifies the caller, and books the appointment. Fits alongside the existing entries (SiteGPT, GPTHelp.ai, Dear AI, Aidbase, Twig). One tool added, one line changed, existing formatting followed.

## ✅ Checklist

✅ Only one tool is modified in this PR
✅ Added to an appropriate, existing category (Customer Support)
✅ Entry follows the existing `- [Name](url) - Description.` format