### PR TITLE
Add Vibes DIY

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- [Vibes DIY](https://vibes.diy/) - Open-source AI app builder: describe an app in plain English and get a real, live web app you can share, remix, and collaborate on.
 
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
 - [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
-- [Vibes DIY](https://vibes.diy/) - Open-source AI app builder: describe an app in plain English and get a real, live web app you can share, remix, and collaborate on.
+- [Vibes DIY](https://vibes.diy/) - [Open-source](https://github.com/VibesDIY/vibes.diy) AI app builder: describe an app in plain English and get a real, live web app you can share, remix, and collaborate on.
 
 
 ## Image


### PR DESCRIPTION
Adds [Vibes DIY](https://vibes.diy/) to **Code**. Open-source (Apache-2.0) AI app builder: describe an app in plain English and get a real, live web app at its own URL — shareable, remixable, with collaborative data. Single entry appended to the section.