### PR TITLE
Add SNTL — Helium/Solana DePIN threat-intelligence x402 agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ChatWithCloud](https://chatwithcloud.ai/) - CLI allowing you to interact with AWS Cloud using human language inside your Terminal.
 - [SinglebaseCloud](https://singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.
 - [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
+- [SNTL — Helium Intelligence](https://a2a.sntl.site) - Pay-per-call Helium/Solana DePIN threat & wallet intelligence over x402; $0.01 USDC, no signup, no API key.
 - [Wordware](https://www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
 - [CodeRabbit](https://coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  

--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [ChatWithCloud](https://chatwithcloud.ai/) - CLI allowing you to interact with AWS Cloud using human language inside your Terminal.
 - [SinglebaseCloud](https://singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.
 - [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
-- [SNTL — Helium Intelligence](https://a2a.sntl.site) - Pay-per-call Helium/Solana DePIN threat & wallet intelligence over x402; $0.01 USDC, no signup, no API key.
 - [Wordware](https://www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
 - [CodeRabbit](https://coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
 - [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
@@ -271,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [SNTL — Helium Intelligence](https://a2a.sntl.site) - Pay-per-call Helium/Solana DePIN threat & wallet intelligence over x402; $0.01 USDC, no signup, no API key.
 
 
 ## Code


### PR DESCRIPTION
threat & wallet intelligence over x402 ($0.01 USDC, first tier free, no signup).
- **Tool URL:** https://a2a.sntl.site
- **Altern.ai page link:** —

## 📌 Description
Added a new AI tool, **SNTL — Helium Intelligence**, to the **end of the Developer tools** category. It's a live x402 pay-per-call API serving Helium/Solana DePIN threat classification, anomaly scoring, wallet intelligence, and forensic event chains over a 600K+ event datalake.

---

## ✅ Checklist
- [x] I have read the Contribution Guidelines
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool

---

## 📷 Screenshots / Demo (if applicable)
Served agent-card: https://a2a.sntl.site/.well-known/agent-card.json

---

## 💡 Additional Notes
Live x402 standard on Solana mainnet (gasless via PayAI facilitator). Public source: https://github.com/substreambc/my-agent


<img width="1366" height="767" alt="Screenshot 2026-06-28 8 49 12 PM" src="https://github.com/user-attachments/assets/0557f3b1-9c43-4199-9053-3da5be39dc45" />
<img width="1366" height="767" alt="Screenshot 2026-06-28 8 26 55 PM" src="https://github.com/user-attachments/assets/e51dc565-6eea-453c-882f-544d4a5cf94d" />
