### PR TITLE
Add AI Model Watch to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [AI Model Watch](https://aimodelwatch.dev/) - Tracks prices, context windows, and end-of-life dates for 180+ LLMs across every major provider, updated daily from official docs, with free email alerts on price changes and deprecations.
 
 
 ## Code


### PR DESCRIPTION
## 📝 New Tool Information
- **Tool Name:** AI Model Watch
- **Description:** Tracks prices, context windows, and end-of-life dates for 180+ LLMs across every major provider, updated daily from official docs, with free email alerts on price changes and deprecations.
- **Tool URL:** https://aimodelwatch.dev/
- **Altern.ai page link:** (not listed)

## 📌 Description
Added **AI Model Watch** to the end of the **Text → Developer tools** category. It's a free, daily-updated reference that developers use to compare LLM API prices/context windows and to see which models are being deprecated — a natural neighbor to the existing "OpenAI Downtime Monitor" tracking entry in the same section.

---

## ✅ Checklist
- [x] I have read the Contribution Guidelines
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [x] ➕ Adding a new AI tool
