### PR TITLE
Add Clavio to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Productivity
 
+- [Clavio](https://clavioapp.com) - AI hands-free dictation for Mac: speak in any app and clean, punctuated text types itself, with per-app tone and optional auto-send. [`brew install --cask zhingel/clavio/clavio`]
 - [Mem](https://mem.ai/) - Mem is the world's first AI-powered workspace that's personalized to you. Amplify your creativity, automate the mundane, and stay organized automatically.
 - [Taskade](https://www.taskade.com/) -  Build, train, and deploy autonomous AI agents for task management, team collaboration, and workflow automation—all within a unified workspace.
 - [Notion AI](https://www.notion.so/product/ai) - Write better, more efficient notes and docs.


### PR DESCRIPTION
Adds Clavio to the Productivity section — an AI dictation app for Mac: speak in any app and clean, punctuated text types itself, with per-app tone and optional auto-send. Installs via brew install --cask zhingel/clavio/clavio. Free tier — https://clavioapp.com