### PR TITLE
Add OpenAgentRelay to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Cleanlab](https://help.cleanlab.ai/tlm/) - Detect and remediate hallucinations in any LLM application.
 - [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows.
+- [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) - Open-source Python CLI for exposing a restricted local agent or automation as a capability callable by teammates and other agents over a trusted LAN.
 - [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
 - [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
 - [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.


### PR DESCRIPTION
Adds OpenAgentRelay under **Developer tools**. It is an Apache-2.0 Python CLI for exposing a restricted Codex command, another local agent, or an automation as a trusted-LAN capability callable by teammates and other agents.

The entry is concise and keeps the Alpha security limitation explicit.