### PR TITLE
Add AI Fast Club to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 ### Developer tools
 
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
-- [AI Fast Club](https://www.aifast.club) - Unified AI API gateway with OpenAI-compatible access to Claude Opus 4.8, GPT-5.6, Gemini 3 and 570+ other models, with domestic Chinese payment support.
+- [AI Fast Club](https://www.aifast.club) - Unified AI API gateway with OpenAI-compatible access to 500+ global and Chinese models, including Claude, GPT, Gemini, DeepSeek, and Qwen, with Alipay/WeChat payment support.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
 - [Keploy](https://keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 ### Developer tools
 
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
+- [AI Fast Club](https://www.aifast.club) - Unified AI API gateway with OpenAI-compatible access to Claude Opus 4.8, GPT-5.6, Gemini 3 and 570+ other models, with domestic Chinese payment support.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
 - [Keploy](https://keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 ### Developer tools
 
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
-- [AI Fast Club](https://www.aifast.club) - Unified AI API gateway with OpenAI-compatible access to 500+ global and Chinese models, including Claude, GPT, Gemini, DeepSeek, and Qwen, with Alipay/WeChat payment support.
+- [AI Fast Club](https://www.aifast.hk) - OpenAI-compatible AI API gateway with access to 500+ global and Chinese models, including Claude, GPT, Gemini, DeepSeek, and Qwen.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
 - [Keploy](https://keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.


### PR DESCRIPTION
Adds **AI Fast Club** to the Developer tools list.\n\nAI Fast Club is an OpenAI-compatible API gateway providing access to 500+ global and Chinese models, including Claude, GPT, Gemini, DeepSeek, and Qwen. It supports Alipay and WeChat payments.\n\nThis PR changes one file and adds one list entry following the existing format.