### PR TITLE
Add Markstream Vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### Developer tools
 
+- [Markstream Vue](https://github.com/Simon-He95/markstream-vue) - MIT-licensed streaming Markdown renderer for AI chat interfaces, supporting incomplete Markdown, Mermaid diagrams, KaTeX, streaming code blocks, SSR, and Vue, React, Svelte, and Angular integrations.
 - [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
 - [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
 - [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.


### PR DESCRIPTION
## 📝 New Tool Information

- **Tool Name:** Markstream Vue
- **Description:** MIT-licensed streaming Markdown renderer for AI chat interfaces with Vue, React, Svelte, and Angular integrations.
- **Tool URL:** https://github.com/Simon-He95/markstream-vue
- **Altern.ai page link:** Not available

## 📌 Description

Added Markstream Vue to Developer tools.

---

## ✅ Checklist
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md) — no CONTRIBUTING.md is currently present in this repository.
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [x] 📚 Documentation / README update
- [x] ➕ Adding a new AI tool
- [ ] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix
- [ ] Other (please specify):

---

## 📷 Screenshots / Demo (if applicable)

Live documentation and demo: https://markstream-vue.simonhe.me/

---

## 💡 Additional Notes

I maintain the project.