### PR TITLE
Add PrismPoster to AI tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
 - [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
 - [Sisif](https://sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
+- [PrismPoster](https://www.prismposter.com) - AI content workspace with image, video, and music studios that share one project timeline and asset library.
 
 
 ### Animation


### PR DESCRIPTION
## 📄 New Tool Information
- **Tool Name:** PrismPoster
- **Description:** AI content workspace with image, video, and music studios that share one project timeline and asset library.
- **Tool URL:** https://www.prismposter.com
- **Altern.ai page link:** Not listed on Altern.ai.


## 📌 Description

Adds PrismPoster to the **Video** section — a single new entry, appended at the end of that category.

PrismPoster is an AI content workspace covering image, video, and music generation with a shared editing timeline, so a clip and its soundtrack can be produced and assembled in one place rather than across separate tools. Free tier available, no card required.

Verified before opening: the URL resolves (HTTP 200), "PrismPoster" does not already appear anywhere in the README, and the entry's formatting matches the surrounding lines exactly (`- [Name](url) - Description.`).

---

## ✅ Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **Only one tool is modified in this PR**
- [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [x] The tool link is **valid** and accessible
- [x] The tool is **not already listed**
- [x] The tool is placed in the **correct category**
- [x] **The tool is added at the *end* of its category**
- [x] No unrelated changes included in this PR

---

## 🛠 Type of Change
- [x] 📚 Documentation / README update
- [x] ➕ Adding a new AI tool
- [ ] 🗑 Removing a deprecated/invalid AI tool
- [ ] ♻️ Refactoring or reorganizing existing entries
- [ ] 🐛 Bug fix
- [ ] Other (please specify):

---

## 📸 Screenshots / Demo (if applicable)

Not applicable — README-only change. The tool itself is at https://www.prismposter.com.

---

## 💡 Additional Notes

Single-line addition at line 405, directly after `Sisif` and before the `### Animation` subsection. Happy to move it to a different category or reword the description if you'd prefer something shorter.