### PR TITLE
Add kynth-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [kynth-mcp](https://github.com/kyisaiah47/kynth-mcp) - MCP server from Kynth Studios — eleven read-only lookups over live public data: agent skills and configs, shadcn component registries.
 
 
 ## Code


### PR DESCRIPTION
Adds **kynth-mcp** under _Developer tools_.

MCP server from Kynth Studios — eleven read-only lookups over live public data: agent skills and configs, shadcn component registries, AI…

- Site: https://github.com/kyisaiah47/kynth-mcp

One line, in the format the surrounding entries use. Happy to move it to a different section or reword it.