### PR TITLE
Add Daily AI Intel Free Tools to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Google Sheets Formula Generator](https://bettersheets.co/google-sheets-formula-generator?ref=mahseema-awesome-ai-tools) - Forget about frustrating formulas in Google Sheets.
 - [CreateEasily](https://createeasily.com/?ref=mahseema-awesome-ai-tools) - Free speech-to-text tool for content creators that accurately transcribes audio & video files up to 2GB.
 - [Cosmos](https://meetcosmos.com/) - Use AI locally and offline to search your media files by their content, find similar images or video scenes using reference images, and transcribe video.
+- [Daily AI Intel Free Tools](https://dailyaiintel.com/tools) - A collection of 19 free, no-signup AI tools that run entirely in the browser, including an AI cost calculator, a model comparison table, a system prompt builder, and a prompt template library.
 - [aiPDF](https://aipdf.ai) - The most advanced AI document assistant
 - [Summary With AI](https://www.summarywithai.com/) - Summarize any long PDF with AI. Comprehensive summaries using information from all pages of a document.
 - [Emilio](https://getemil.io?ref=mahseema-awesome-ai-tools) - Stop drowning in emails - Emilio prioritizes and automates your email, saving 60% of your time


### PR DESCRIPTION
## New Tool Information

Tool Name: Daily AI Intel Free Tools
Description: A collection of 19 free, no-signup AI tools that run entirely in the browser, including an AI cost calculator, a model comparison table, a system prompt builder, and a prompt template library.
Tool URL: https://dailyaiintel.com/tools
Altern.ai page link: N/A

## Description

Added Daily AI Intel Free Tools to the Productivity section, placed after the existing Cosmos entry.

## Checklist

I have read the Contribution Guidelines. Only one tool is modified in this PR. All required fields above are provided. The tool link is valid and accessible. The tool is not already listed. The tool is placed in the correct category. The tool is added at the end of its category. No unrelated changes are included in this PR.