### PR TITLE
Add Agentwire

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [Agentwire](https://agentwire.kynth.studio) - MCP servers, coding-agent harnesses and agent frameworks, indexed.
 
 
 ## Code


### PR DESCRIPTION
Adds **Agentwire** under _Developer tools_.

MCP servers, coding-agent harnesses and agent frameworks, indexed.

- Site: https://agentwire.kynth.studio

One line, in the format the surrounding entries use. Happy to move it to a different section or reword it.