### PR TITLE
Add BlockDex

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [MemFree](https://github.com/memfreeme/memfree) - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs
 - [Refinder AI](https://refinder.ai/) - AI-powered universal search and assistant for work
 - [Agentset.ai](https://agentset.ai/) - Open-source local Semantic Search + RAG for your data
+- [BlockDex](https://blockdex.kynth.studio) - Item-level search across every public shadcn registry.
 
 ### Local search engines
 


### PR DESCRIPTION
Adds **BlockDex** under _Search engines_.

Item-level search across every public shadcn registry.

- Site: https://blockdex.kynth.studio

One line, in the format the surrounding entries use. Happy to move it to a different section or reword it.