### PR TITLE
Add ParseRail

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
 - [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
 - [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- [ParseRail](https://parserail.kynth.studio) - Production AI endpoints behind one key and a pay-per-call credit wallet — the same engine under every app Kynth ships.
 
 
 ## Code


### PR DESCRIPTION
Adds **ParseRail** under _Developer tools_.

Production AI endpoints behind one key and a pay-per-call credit wallet — the same engine under every app Kynth ships, solved once and run…

- Site: https://parserail.kynth.studio

One line, in the format the surrounding entries use. Happy to move it to a different section or reword it.