### PR TITLE
Add Veida to Image / Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - [AI Photo Forge](https://aiphotoforge.com/) - A Telegram bot to generate AI pictures of you.
 - [AI Boost](https://boost.pictures/) - All-in-one service for creating and editing images with AI: upscale images, swap faces, generate new visuals and avatars, try on outfits, reshape body contours, change backgrounds, retouch faces, and even test out tattoos.
 - [PlantTattoosAI](https://www.planttattoosai.com/) - Plant and flower tattoos designs generator trained on real botanicals.
+- [Veida](https://veida.ai/) - Text-to-image generator with a free tier that runs without an account or API key.
 
 
 


### PR DESCRIPTION
Adds Veida to Image → Models.

Text-to-image generator whose free tier runs without an account or API key. Same format as the surrounding entries.
